### PR TITLE
Strengthen tests, docs, recipes, and add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "27"
-          gleam-version: "1.15.2"
+          gleam-version: "1.15"
 
       - run: gleam deps download
       - run: gleam format --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    name: Publish to Hex
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27"
+          gleam-version: "1.15.2"
+
+      - run: gleam deps download
+      - run: gleam format --check
+      - run: gleam build --warnings-as-errors
+      - run: gleam test
+      - run: gleam publish -y
+        env:
+          HEXPM_API_KEY: ${{ secrets.HEXPM_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -59,6 +59,157 @@ pub fn validate_user(name: String, age: Int) -> Validated(User, Err) {
 // validate_user("", -1)           -> Invalid([NameEmpty, AgeTooYoung])
 ```
 
+## Examples
+
+### Field validation with structured error context
+
+Attach field names to errors so callers can identify which field failed.
+
+```gleam
+import dataprep/prep
+import dataprep/rules
+import dataprep/validated.{type Validated}
+import dataprep/validator
+
+pub type FormError {
+  Field(name: String, detail: FieldDetail)
+}
+
+pub type FieldDetail {
+  Empty
+  TooShort(min: Int)
+  TooLong(max: Int)
+}
+
+pub fn validate_username(raw: String) -> Validated(String, FormError) {
+  let clean = prep.trim() |> prep.then(prep.lowercase())
+  let check =
+    rules.not_empty(Empty)
+    |> validator.guard(
+      rules.min_length(3, TooShort(3))
+      |> validator.both(rules.max_length(20, TooLong(20))),
+    )
+    |> validator.label("username", Field)
+
+  raw |> clean |> check
+}
+
+// validate_username("  Al  ")
+//   -> Invalid([Field("username", TooShort(3))])
+// validate_username("  Alice  ")
+//   -> Valid("alice")
+```
+
+### Parse then validate
+
+Use `validated.and_then` to bridge type-changing parsing with
+same-type validation. Parsing short-circuits; validation accumulates.
+
+```gleam
+import dataprep/rules
+import dataprep/validated.{type Validated}
+import gleam/int
+
+pub type AgeError {
+  NotAnInteger(raw: String)
+  TooYoung(min: Int)
+  TooOld(max: Int)
+}
+
+fn parse_int(raw: String) -> Validated(Int, AgeError) {
+  raw
+  |> int.parse
+  |> result.map_error(fn(_) { NotAnInteger(raw) })
+  |> validated.from_result
+}
+
+pub fn validate_age(raw: String) -> Validated(Int, AgeError) {
+  let check_range =
+    rules.min_int(0, TooYoung(0))
+    |> validator.both(rules.max_int(150, TooOld(150)))
+
+  parse_int(raw)
+  |> validated.and_then(check_range)
+}
+
+// validate_age("abc") -> Invalid([NotAnInteger("abc")])
+// validate_age("200") -> Invalid([TooOld(150)])
+// validate_age("25")  -> Valid(25)
+```
+
+### Nested error labeling with map3
+
+Combine multiple fields into a domain type. All errors from all
+fields are accumulated with their field names.
+
+```gleam
+import dataprep/prep
+import dataprep/rules
+import dataprep/validated.{type Validated}
+import dataprep/validator
+
+pub type SignupForm {
+  SignupForm(name: String, email: String, age: Int)
+}
+
+pub type SignupError {
+  Field(name: String, detail: Detail)
+}
+
+pub type Detail {
+  Empty
+  TooShort(min: Int)
+  OutOfRange(min: Int, max: Int)
+}
+
+fn validate_name(raw: String) -> Validated(String, SignupError) {
+  let clean = prep.trim() |> prep.then(prep.lowercase())
+  let check =
+    rules.not_empty(Empty)
+    |> validator.guard(rules.min_length(2, TooShort(2)))
+    |> validator.label("name", Field)
+  raw |> clean |> check
+}
+
+fn validate_email(raw: String) -> Validated(String, SignupError) {
+  let clean = prep.trim() |> prep.then(prep.lowercase())
+  let check =
+    rules.not_empty(Empty)
+    |> validator.label("email", Field)
+  raw |> clean |> check
+}
+
+fn validate_age(age: Int) -> Validated(Int, SignupError) {
+  let check =
+    rules.min_int(0, OutOfRange(0, 150))
+    |> validator.both(rules.max_int(150, OutOfRange(0, 150)))
+    |> validator.label("age", Field)
+  check(age)
+}
+
+pub fn validate_signup(
+  name: String,
+  email: String,
+  age: Int,
+) -> Validated(SignupForm, SignupError) {
+  validated.map3(
+    SignupForm,
+    validate_name(name),
+    validate_email(email),
+    validate_age(age),
+  )
+}
+
+// validate_signup("", "", 200)
+//   -> Invalid([
+//        Field("name", Empty),
+//        Field("email", Empty),
+//        Field("age", OutOfRange(0, 150)),
+//      ])
+```
+
+See [doc/recipes/](doc/recipes/) for more examples.
+
 ## Modules
 
 | Module | Responsibility |

--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ same-type validation. Parsing short-circuits; validation accumulates.
 ```gleam
 import dataprep/rules
 import dataprep/validated.{type Validated}
+import dataprep/validator
 import gleam/int
+import gleam/result
 
 pub type AgeError {
   NotAnInteger(raw: String)
@@ -208,7 +210,7 @@ pub fn validate_signup(
 //      ])
 ```
 
-See [doc/recipes/](doc/recipes/) for more examples.
+More examples are available in the [doc/recipes/](doc/recipes/) directory of the repository.
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Hex.pm](https://img.shields.io/hexpm/v/dataprep)](https://hex.pm/packages/dataprep)
 
 
-![dataprep_logo](./doc/img/dataprep-logo-small.png)
+![dataprep_logo](https://raw.githubusercontent.com/nao1215/dataprep/main/doc/img/dataprep-logo-small.png)
 
 Composable, type-driven preprocessing and validation combinator library for Gleam.
 
@@ -210,7 +210,7 @@ pub fn validate_signup(
 //      ])
 ```
 
-More examples are available in the [doc/recipes/](doc/recipes/) directory of the repository.
+More examples are available in the [doc/recipes/](https://github.com/nao1215/dataprep/tree/main/doc/recipes) directory of the repository.
 
 ## Modules
 
@@ -248,8 +248,8 @@ just check      # all checks without deps download
 
 ## Contributing
 
-Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+Contributions are welcome. See [CONTRIBUTING.md](https://github.com/nao1215/dataprep/blob/main/CONTRIBUTING.md) for details.
 
 ## License
 
-[MIT](LICENSE)
+[MIT](https://github.com/nao1215/dataprep/blob/main/LICENSE)

--- a/doc/recipes/api_payload.md
+++ b/doc/recipes/api_payload.md
@@ -1,0 +1,117 @@
+# Recipe: API Payload Validation
+
+Validate a JSON API request payload after decoding.
+Demonstrates alt (accept multiple formats) and guard
+(prerequisite checks before expensive validation).
+
+```gleam
+import dataprep/prep
+import dataprep/rules
+import dataprep/validated.{type Validated}
+import dataprep/validator
+import gleam/string
+
+pub type CreatePostRequest {
+  CreatePostRequest(title: String, slug: String, status: String)
+}
+
+pub type ApiError {
+  Field(name: String, detail: ApiDetail)
+}
+
+pub type ApiDetail {
+  Required
+  TooShort(min: Int)
+  TooLong(max: Int)
+  InvalidSlug
+  InvalidUuid
+  InvalidIdFormat
+  InvalidStatus
+}
+
+// --- Slug / UUID-like checks ---
+
+fn is_slug(s: String) -> Bool {
+  s
+  |> string.to_graphemes
+  |> list.all(fn(c) {
+    c == "-" || { c >= "a" && c <= "z" } || { c >= "0" && c <= "9" }
+  })
+}
+
+fn is_uuid_like(s: String) -> Bool {
+  string.length(s) == 36 && string.contains(s, "-")
+}
+
+// --- Field processors ---
+
+fn validate_title(raw: String) -> Validated(String, ApiError) {
+  let clean = prep.trim()
+  let check =
+    rules.not_empty(Required)
+    |> validator.guard(
+      rules.min_length(3, TooShort(3))
+      |> validator.both(rules.max_length(200, TooLong(200))),
+    )
+    |> validator.label("title", Field)
+
+  raw |> clean |> check
+}
+
+fn validate_slug(raw: String) -> Validated(String, ApiError) {
+  let clean = prep.trim() |> prep.then(prep.lowercase())
+
+  // Accept either a slug or a UUID
+  let check =
+    validator.predicate(is_slug, InvalidSlug)
+    |> validator.alt(validator.predicate(is_uuid_like, InvalidUuid))
+    |> validator.map_error(fn(_) { InvalidIdFormat })
+    |> validator.label("slug", Field)
+
+  raw |> clean |> check
+}
+
+fn validate_status(raw: String) -> Validated(String, ApiError) {
+  let clean = prep.trim() |> prep.then(prep.lowercase())
+  let check =
+    rules.one_of(["draft", "published", "archived"], InvalidStatus)
+    |> validator.label("status", Field)
+
+  raw |> clean |> check
+}
+
+// --- Combine ---
+
+pub fn validate_create_post(
+  title: String,
+  slug: String,
+  status: String,
+) -> Validated(CreatePostRequest, ApiError) {
+  validated.map3(
+    CreatePostRequest,
+    validate_title(title),
+    validate_slug(slug),
+    validate_status(status),
+  )
+}
+
+// validate_create_post("", "INVALID!!!", "unknown")
+//   -> Invalid([
+//        Field("title", Required),
+//        Field("slug", InvalidIdFormat),
+//        Field("status", InvalidStatus),
+//      ])
+//
+// validate_create_post("My Post", "my-post", "draft")
+//   -> Valid(CreatePostRequest("My Post", "my-post", "draft"))
+//
+// validate_create_post("My Post", "550e8400-e29b-41d4-a716-446655440000", "published")
+//   -> Valid(CreatePostRequest("My Post", "550e8400-e29b-41d4-a716-446655440000", "published"))
+```
+
+Key patterns used:
+- `validator.alt` to accept either slug or UUID format
+- `validator.map_error` to simplify alt's accumulated errors into a single error
+- `rules.one_of` for enum-like validation
+- `validator.guard` to skip length checks when the field is empty
+- `validated.map3` for field-level error accumulation

--- a/doc/recipes/api_payload.md
+++ b/doc/recipes/api_payload.md
@@ -9,6 +9,7 @@ import dataprep/prep
 import dataprep/rules
 import dataprep/validated.{type Validated}
 import dataprep/validator
+import gleam/list
 import gleam/string
 
 pub type CreatePostRequest {
@@ -32,9 +33,9 @@ pub type ApiDetail {
 // --- Slug / UUID-like checks ---
 
 fn is_slug(s: String) -> Bool {
-  s
-  |> string.to_graphemes
-  |> list.all(fn(c) {
+  let chars = string.to_graphemes(s)
+  chars != []
+  && list.all(chars, fn(c) {
     c == "-" || { c >= "a" && c <= "z" } || { c >= "0" && c <= "9" }
   })
 }
@@ -61,11 +62,14 @@ fn validate_title(raw: String) -> Validated(String, ApiError) {
 fn validate_slug(raw: String) -> Validated(String, ApiError) {
   let clean = prep.trim() |> prep.then(prep.lowercase())
 
-  // Accept either a slug or a UUID
+  // non-empty guard, then accept either a slug or a UUID
   let check =
-    validator.predicate(is_slug, InvalidSlug)
-    |> validator.alt(validator.predicate(is_uuid_like, InvalidUuid))
-    |> validator.map_error(fn(_) { InvalidIdFormat })
+    rules.not_empty(Required)
+    |> validator.guard(
+      validator.predicate(is_slug, InvalidSlug)
+      |> validator.alt(validator.predicate(is_uuid_like, InvalidUuid))
+      |> validator.map_error(fn(_) { InvalidIdFormat }),
+    )
     |> validator.label("slug", Field)
 
   raw |> clean |> check

--- a/doc/recipes/csv_row.md
+++ b/doc/recipes/csv_row.md
@@ -1,0 +1,107 @@
+# Recipe: CSV Row Validation
+
+Validate a row of CSV data where all values arrive as strings.
+Demonstrates preprocessing, parsing, and multi-field accumulation.
+
+```gleam
+import dataprep/prep
+import dataprep/rules
+import dataprep/validated.{type Validated}
+import dataprep/validator
+import gleam/float
+import gleam/int
+
+pub type Product {
+  Product(name: String, quantity: Int, price: Float)
+}
+
+pub type RowError {
+  Cell(column: String, detail: CellDetail)
+}
+
+pub type CellDetail {
+  Empty
+  TooLong(max: Int)
+  NotAnInteger(raw: String)
+  NotAFloat(raw: String)
+  Negative
+}
+
+// --- Parse helpers ---
+
+fn parse_int(raw: String, col: String) -> Validated(Int, RowError) {
+  raw
+  |> int.parse
+  |> result.map_error(fn(_) { Cell(col, NotAnInteger(raw)) })
+  |> validated.from_result
+}
+
+fn parse_float(raw: String, col: String) -> Validated(Float, RowError) {
+  raw
+  |> float.parse
+  |> result.map_error(fn(_) { Cell(col, NotAFloat(raw)) })
+  |> validated.from_result
+}
+
+// --- Field processors ---
+
+fn validate_name(raw: String) -> Validated(String, RowError) {
+  let clean = prep.trim()
+  let check =
+    rules.not_empty(Empty)
+    |> validator.guard(rules.max_length(100, TooLong(100)))
+    |> validator.label("name", Cell)
+
+  raw |> clean |> check
+}
+
+fn validate_quantity(raw: String) -> Validated(Int, RowError) {
+  let cleaned = prep.trim()(raw)
+  parse_int(cleaned, "quantity")
+  |> validated.and_then(
+    rules.min_int(0, Negative)
+    |> validator.label("quantity", Cell),
+  )
+}
+
+fn validate_price(raw: String) -> Validated(Float, RowError) {
+  let cleaned = prep.trim()(raw)
+  parse_float(cleaned, "price")
+  |> validated.and_then(
+    validator.predicate(fn(x) { x >=. 0.0 }, Negative)
+    |> validator.label("price", Cell),
+  )
+}
+
+// --- Combine ---
+
+pub fn validate_row(
+  name: String,
+  quantity: String,
+  price: String,
+) -> Validated(Product, RowError) {
+  validated.map3(
+    Product,
+    validate_name(name),
+    validate_quantity(quantity),
+    validate_price(price),
+  )
+}
+
+// validate_row("", "abc", "-1.5")
+//   -> Invalid([
+//        Cell("name", Empty),
+//        Cell("quantity", NotAnInteger("abc")),
+//        Cell("price", Negative),
+//      ])
+//
+// validate_row("  Widget  ", "10", "29.99")
+//   -> Valid(Product("Widget", 10, 29.99))
+```
+
+Key patterns used:
+- `prep.trim()` applied inline before parsing
+- `validated.from_result` to bridge `int.parse` / `float.parse`
+- `validated.and_then` to chain parse-then-validate for each cell
+- `validator.label` with `Cell` wrapper for column-level error context
+- `validated.map3` to accumulate errors across all columns in a row

--- a/doc/recipes/csv_row.md
+++ b/doc/recipes/csv_row.md
@@ -10,6 +10,7 @@ import dataprep/validated.{type Validated}
 import dataprep/validator
 import gleam/float
 import gleam/int
+import gleam/result
 
 pub type Product {
   Product(name: String, quantity: Int, price: Float)

--- a/doc/recipes/query_params.md
+++ b/doc/recipes/query_params.md
@@ -47,7 +47,7 @@ fn validate_query(raw: String) -> Validated(String, ParamError) {
 }
 
 fn validate_page(raw: String) -> Validated(Int, ParamError) {
-  parse_int(raw, "page")
+  parse_int(prep.trim()(raw), "page")
   |> validated.and_then(
     rules.min_int(1, TooSmall(1))
     |> validator.label("page", Param),
@@ -55,7 +55,7 @@ fn validate_page(raw: String) -> Validated(Int, ParamError) {
 }
 
 fn validate_per_page(raw: String) -> Validated(Int, ParamError) {
-  parse_int(raw, "per_page")
+  parse_int(prep.trim()(raw), "per_page")
   |> validated.and_then(
     rules.min_int(1, TooSmall(1))
     |> validator.both(rules.max_int(100, TooBig(100)))

--- a/doc/recipes/query_params.md
+++ b/doc/recipes/query_params.md
@@ -1,0 +1,95 @@
+# Recipe: Query Parameter Validation
+
+Validate HTTP query parameters where values arrive as strings
+and must be parsed into typed values before validation.
+
+```gleam
+import dataprep/prep
+import dataprep/rules
+import dataprep/validated.{type Validated}
+import dataprep/validator
+import gleam/int
+
+pub type SearchQuery {
+  SearchQuery(query: String, page: Int, per_page: Int)
+}
+
+pub type ParamError {
+  Param(name: String, detail: ParamDetail)
+}
+
+pub type ParamDetail {
+  Missing
+  NotAnInteger(raw: String)
+  TooSmall(min: Int)
+  TooBig(max: Int)
+}
+
+// --- Parse helpers ---
+
+fn parse_int(raw: String, param_name: String) -> Validated(Int, ParamError) {
+  raw
+  |> int.parse
+  |> result.map_error(fn(_) { Param(param_name, NotAnInteger(raw)) })
+  |> validated.from_result
+}
+
+// --- Field processors ---
+
+fn validate_query(raw: String) -> Validated(String, ParamError) {
+  let clean = prep.trim()
+  let check =
+    rules.not_empty(Missing)
+    |> validator.label("q", Param)
+
+  raw |> clean |> check
+}
+
+fn validate_page(raw: String) -> Validated(Int, ParamError) {
+  parse_int(raw, "page")
+  |> validated.and_then(
+    rules.min_int(1, TooSmall(1))
+    |> validator.label("page", Param),
+  )
+}
+
+fn validate_per_page(raw: String) -> Validated(Int, ParamError) {
+  parse_int(raw, "per_page")
+  |> validated.and_then(
+    rules.min_int(1, TooSmall(1))
+    |> validator.both(rules.max_int(100, TooBig(100)))
+    |> validator.label("per_page", Param),
+  )
+}
+
+// --- Combine ---
+
+pub fn validate_search(
+  query: String,
+  page: String,
+  per_page: String,
+) -> Validated(SearchQuery, ParamError) {
+  validated.map3(
+    SearchQuery,
+    validate_query(query),
+    validate_page(page),
+    validate_per_page(per_page),
+  )
+}
+
+// validate_search("", "abc", "200")
+//   -> Invalid([
+//        Param("q", Missing),
+//        Param("page", NotAnInteger("abc")),
+//        Param("per_page", TooBig(100)),
+//      ])
+//
+// validate_search("gleam", "1", "25")
+//   -> Valid(SearchQuery("gleam", 1, 25))
+```
+
+Key patterns used:
+- `validated.from_result` to bridge `int.parse` into Validated
+- `validated.and_then` to chain parsing (type-changing) with validation
+- `validator.label` with a `Param` wrapper for structured errors
+- `validated.map3` to combine independent fields

--- a/doc/recipes/query_params.md
+++ b/doc/recipes/query_params.md
@@ -9,6 +9,7 @@ import dataprep/rules
 import dataprep/validated.{type Validated}
 import dataprep/validator
 import gleam/int
+import gleam/result
 
 pub type SearchQuery {
   SearchQuery(query: String, page: Int, per_page: Int)

--- a/doc/recipes/signup_form.md
+++ b/doc/recipes/signup_form.md
@@ -1,0 +1,100 @@
+# Recipe: Signup Form Validation
+
+Validate a signup form with name, email, and password fields.
+Each field is preprocessed, validated independently, and errors
+are accumulated with field labels.
+
+```gleam
+import dataprep/prep
+import dataprep/rules
+import dataprep/validated.{type Validated}
+import dataprep/validator
+import gleam/string
+
+pub type SignupForm {
+  SignupForm(name: String, email: String, password: String)
+}
+
+pub type FormError {
+  Field(name: String, detail: FieldDetail)
+}
+
+pub type FieldDetail {
+  Empty
+  TooShort(min: Int)
+  TooLong(max: Int)
+  NoAtSign
+}
+
+// --- Field processors ---
+
+fn validate_name(raw: String) -> Validated(String, FormError) {
+  let clean =
+    prep.sequence([prep.trim(), prep.lowercase(), prep.collapse_space()])
+  let check =
+    rules.not_empty(Empty)
+    |> validator.guard(
+      rules.min_length(2, TooShort(2))
+      |> validator.both(rules.max_length(50, TooLong(50))),
+    )
+    |> validator.label("name", Field)
+
+  raw |> clean |> check
+}
+
+fn validate_email(raw: String) -> Validated(String, FormError) {
+  let clean = prep.trim() |> prep.then(prep.lowercase())
+  let check =
+    rules.not_empty(Empty)
+    |> validator.guard(
+      validator.predicate(fn(s) { string.contains(s, "@") }, NoAtSign),
+    )
+    |> validator.label("email", Field)
+
+  raw |> clean |> check
+}
+
+fn validate_password(raw: String) -> Validated(String, FormError) {
+  let check =
+    rules.not_empty(Empty)
+    |> validator.guard(
+      rules.min_length(8, TooShort(8))
+      |> validator.both(rules.max_length(128, TooLong(128))),
+    )
+    |> validator.label("password", Field)
+
+  check(raw)
+}
+
+// --- Combine ---
+
+pub fn validate_signup(
+  name: String,
+  email: String,
+  password: String,
+) -> Validated(SignupForm, FormError) {
+  validated.map3(
+    SignupForm,
+    validate_name(name),
+    validate_email(email),
+    validate_password(password),
+  )
+}
+
+// validate_signup("", "bad", "short")
+//   -> Invalid([
+//        Field("name", Empty),
+//        Field("email", NoAtSign),
+//        Field("password", TooShort(8)),
+//      ])
+//
+// validate_signup("  Alice  ", "ALICE@EXAMPLE.COM", "securepass123")
+//   -> Valid(SignupForm("alice", "alice@example.com", "securepass123"))
+```
+
+Key patterns used:
+- `prep.sequence` for multi-step normalization
+- `validator.guard` to skip length checks on empty strings
+- `validator.both` for independent checks on the same field
+- `validator.label` to tag errors with field names
+- `validated.map3` to combine three fields with error accumulation

--- a/src/dataprep/prep.gleam
+++ b/src/dataprep/prep.gleam
@@ -41,6 +41,10 @@ pub fn uppercase() -> Prep(String) {
 }
 
 /// Collapse consecutive whitespace into a single space.
+///
+/// Uses `let assert` for the regex compilation. The pattern `\s+` is
+/// a fixed, known-valid regular expression, so compilation cannot fail
+/// at runtime. The assert is intentional and safe.
 pub fn collapse_space() -> Prep(String) {
   let assert Ok(re) = regexp.from_string("\\s+")
   fn(s) { regexp.replace(each: re, in: s, with: " ") }

--- a/test/dataprep/non_empty_list_test.gleam
+++ b/test/dataprep/non_empty_list_test.gleam
@@ -1,14 +1,33 @@
 import dataprep/non_empty_list.{NonEmptyList}
 
+// --- single ---
+
 pub fn single_test() {
   let nel = non_empty_list.single(1)
   let assert NonEmptyList(first: 1, rest: []) = nel
 }
 
+pub fn single_string_test() {
+  let nel = non_empty_list.single("a")
+  let assert ["a"] = non_empty_list.to_list(nel)
+}
+
+// --- cons ---
+
 pub fn cons_test() {
   let nel = non_empty_list.single(2) |> non_empty_list.cons(1, _)
   let assert NonEmptyList(first: 1, rest: [2]) = nel
 }
+
+pub fn cons_multiple_test() {
+  let nel =
+    non_empty_list.single(3)
+    |> non_empty_list.cons(2, _)
+    |> non_empty_list.cons(1, _)
+  let assert [1, 2, 3] = non_empty_list.to_list(nel)
+}
+
+// --- append ---
 
 pub fn append_test() {
   let left = NonEmptyList(first: 1, rest: [2])
@@ -16,6 +35,21 @@ pub fn append_test() {
   let result = non_empty_list.append(left, right)
   let assert NonEmptyList(first: 1, rest: [2, 3, 4]) = result
 }
+
+pub fn append_single_to_single_test() {
+  let result =
+    non_empty_list.append(non_empty_list.single(1), non_empty_list.single(2))
+  let assert [1, 2] = non_empty_list.to_list(result)
+}
+
+pub fn append_preserves_order_test() {
+  let left = NonEmptyList(first: "a", rest: ["b"])
+  let right = NonEmptyList(first: "c", rest: ["d"])
+  let assert ["a", "b", "c", "d"] =
+    non_empty_list.to_list(non_empty_list.append(left, right))
+}
+
+// --- concat ---
 
 pub fn concat_test() {
   let a = NonEmptyList(first: 1, rest: [2])
@@ -26,11 +60,33 @@ pub fn concat_test() {
   let assert [1, 2, 3, 4, 5] = non_empty_list.to_list(result)
 }
 
+pub fn concat_single_list_test() {
+  let inner = NonEmptyList(first: 42, rest: [])
+  let lists = NonEmptyList(first: inner, rest: [])
+  let assert [42] = non_empty_list.to_list(non_empty_list.concat(lists))
+}
+
+// --- map ---
+
 pub fn map_test() {
   let nel = NonEmptyList(first: 1, rest: [2, 3])
   let result = non_empty_list.map(nel, fn(x) { x * 2 })
   let assert [2, 4, 6] = non_empty_list.to_list(result)
 }
+
+pub fn map_single_test() {
+  let nel = non_empty_list.single(10)
+  let result = non_empty_list.map(nel, fn(x) { x + 1 })
+  let assert [11] = non_empty_list.to_list(result)
+}
+
+pub fn map_type_change_test() {
+  let nel = NonEmptyList(first: 1, rest: [2, 3])
+  let result = non_empty_list.map(nel, fn(x) { x > 1 })
+  let assert [False, True, True] = non_empty_list.to_list(result)
+}
+
+// --- flat_map ---
 
 pub fn flat_map_test() {
   let nel = NonEmptyList(first: 1, rest: [2])
@@ -41,10 +97,25 @@ pub fn flat_map_test() {
   let assert [1, 10, 2, 20] = non_empty_list.to_list(result)
 }
 
+pub fn flat_map_single_test() {
+  let nel = non_empty_list.single(5)
+  let result =
+    non_empty_list.flat_map(nel, fn(x) { NonEmptyList(first: x, rest: [x + 1]) })
+  let assert [5, 6] = non_empty_list.to_list(result)
+}
+
+// --- to_list ---
+
 pub fn to_list_test() {
   let nel = NonEmptyList(first: "a", rest: ["b", "c"])
   let assert ["a", "b", "c"] = non_empty_list.to_list(nel)
 }
+
+pub fn to_list_single_test() {
+  let assert [42] = non_empty_list.to_list(non_empty_list.single(42))
+}
+
+// --- from_list ---
 
 pub fn from_list_empty_test() {
   let assert Error(Nil) = non_empty_list.from_list([])
@@ -53,4 +124,17 @@ pub fn from_list_empty_test() {
 pub fn from_list_non_empty_test() {
   let assert Ok(nel) = non_empty_list.from_list([1, 2, 3])
   let assert NonEmptyList(first: 1, rest: [2, 3]) = nel
+}
+
+pub fn from_list_single_element_test() {
+  let assert Ok(nel) = non_empty_list.from_list(["x"])
+  let assert NonEmptyList(first: "x", rest: []) = nel
+}
+
+// --- roundtrip ---
+
+pub fn from_list_to_list_roundtrip_test() {
+  let original = [1, 2, 3, 4, 5]
+  let assert Ok(nel) = non_empty_list.from_list(original)
+  let assert [1, 2, 3, 4, 5] = non_empty_list.to_list(nel)
 }

--- a/test/dataprep/prep_test.gleam
+++ b/test/dataprep/prep_test.gleam
@@ -1,34 +1,109 @@
 import dataprep/prep
 
+// --- identity ---
+
 pub fn identity_test() {
   let p = prep.identity()
   let assert "hello" = p("hello")
 }
+
+pub fn identity_empty_test() {
+  let p = prep.identity()
+  let assert "" = p("")
+}
+
+// --- trim ---
 
 pub fn trim_test() {
   let p = prep.trim()
   let assert "hello" = p("  hello  ")
 }
 
+pub fn trim_empty_test() {
+  let assert "" = prep.trim()("")
+}
+
+pub fn trim_only_whitespace_test() {
+  let assert "" = prep.trim()("   \t\n  ")
+}
+
+pub fn trim_no_whitespace_test() {
+  let assert "hello" = prep.trim()("hello")
+}
+
+// --- lowercase ---
+
 pub fn lowercase_test() {
   let p = prep.lowercase()
   let assert "hello" = p("HELLO")
 }
+
+pub fn lowercase_mixed_test() {
+  let assert "hello world" = prep.lowercase()("Hello World")
+}
+
+pub fn lowercase_empty_test() {
+  let assert "" = prep.lowercase()("")
+}
+
+pub fn lowercase_already_lower_test() {
+  let assert "abc" = prep.lowercase()("abc")
+}
+
+// --- uppercase ---
 
 pub fn uppercase_test() {
   let p = prep.uppercase()
   let assert "HELLO" = p("hello")
 }
 
+pub fn uppercase_empty_test() {
+  let assert "" = prep.uppercase()("")
+}
+
+// --- collapse_space ---
+
 pub fn collapse_space_test() {
   let p = prep.collapse_space()
   let assert "a b c" = p("a   b\t\tc")
 }
 
+pub fn collapse_space_single_space_test() {
+  let assert "a b" = prep.collapse_space()("a b")
+}
+
+pub fn collapse_space_leading_trailing_test() {
+  let assert " hello world " = prep.collapse_space()("  hello   world  ")
+}
+
+pub fn collapse_space_empty_test() {
+  let assert "" = prep.collapse_space()("")
+}
+
+pub fn collapse_space_tabs_and_newlines_test() {
+  let assert " a b " = prep.collapse_space()("\t\na\n\n\tb\t")
+}
+
+// --- replace ---
+
 pub fn replace_test() {
   let p = prep.replace("-", "_")
   let assert "foo_bar_baz" = p("foo-bar-baz")
 }
+
+pub fn replace_no_match_test() {
+  let assert "hello" = prep.replace("-", "_")("hello")
+}
+
+pub fn replace_empty_target_test() {
+  let assert "hello" = prep.replace("x", "y")("hello")
+}
+
+pub fn replace_to_empty_test() {
+  let assert "hllo" = prep.replace("e", "")("hello")
+}
+
+// --- default ---
 
 pub fn default_empty_string_test() {
   let p = prep.default("N/A")
@@ -45,10 +120,32 @@ pub fn default_whitespace_only_test() {
   let assert "   " = p("   ")
 }
 
+// --- then (composition) ---
+
 pub fn then_test() {
   let p = prep.trim() |> prep.then(prep.lowercase())
   let assert "hello" = p("  HELLO  ")
 }
+
+pub fn then_order_matters_test() {
+  // trim then default("X") -> "  " becomes "" becomes "X"
+  let p1 = prep.trim() |> prep.then(prep.default("X"))
+  let assert "X" = p1("  ")
+
+  // default("X") then trim -> "  " is not "", so default is no-op, then trim -> ""
+  let p2 = prep.default("X") |> prep.then(prep.trim())
+  let assert "" = p2("  ")
+}
+
+pub fn then_three_steps_test() {
+  let p =
+    prep.trim()
+    |> prep.then(prep.lowercase())
+    |> prep.then(prep.collapse_space())
+  let assert "hello world" = p("  Hello   World  ")
+}
+
+// --- sequence ---
 
 pub fn sequence_test() {
   let p = prep.sequence([prep.trim(), prep.lowercase(), prep.collapse_space()])
@@ -60,9 +157,27 @@ pub fn sequence_empty_test() {
   let assert "unchanged" = p("unchanged")
 }
 
+pub fn sequence_single_test() {
+  let p = prep.sequence([prep.trim()])
+  let assert "hello" = p("  hello  ")
+}
+
+// --- composition patterns ---
+
 pub fn trim_then_default_test() {
   let p = prep.trim() |> prep.then(prep.default("N/A"))
   let assert "N/A" = p("   ")
   let assert "hello" = p("hello")
   let assert "N/A" = p("")
+}
+
+pub fn full_pipeline_test() {
+  let clean =
+    prep.sequence([
+      prep.trim(),
+      prep.lowercase(),
+      prep.collapse_space(),
+      prep.replace(".", ""),
+    ])
+  let assert "john doe jr" = clean("  John.  DOE.  Jr  ")
 }

--- a/test/dataprep/prep_test.gleam
+++ b/test/dataprep/prep_test.gleam
@@ -95,7 +95,7 @@ pub fn replace_no_match_test() {
   let assert "hello" = prep.replace("-", "_")("hello")
 }
 
-pub fn replace_empty_target_test() {
+pub fn replace_absent_target_test() {
   let assert "hello" = prep.replace("x", "y")("hello")
 }
 

--- a/test/dataprep/rules_test.gleam
+++ b/test/dataprep/rules_test.gleam
@@ -2,6 +2,7 @@ import dataprep/non_empty_list
 import dataprep/prep
 import dataprep/rules
 import dataprep/validated.{Invalid, Valid}
+import dataprep/validator
 
 pub type Err {
   IsEmpty
@@ -12,6 +13,8 @@ pub type Err {
   NotAllowed
   NotEqual
 }
+
+// --- not_empty ---
 
 pub fn not_empty_pass_test() {
   let assert Valid("hello") = rules.not_empty(IsEmpty)("hello")
@@ -32,6 +35,12 @@ pub fn not_empty_with_trim_rejects_whitespace_test() {
   let assert [IsEmpty] = non_empty_list.to_list(nel)
 }
 
+pub fn not_empty_single_char_test() {
+  let assert Valid(" ") = rules.not_empty(IsEmpty)(" ")
+}
+
+// --- min_length ---
+
 pub fn min_length_pass_test() {
   let assert Valid("abc") = rules.min_length(3, TooShort(3))("abc")
 }
@@ -40,6 +49,21 @@ pub fn min_length_fail_test() {
   let assert Invalid(nel) = rules.min_length(3, TooShort(3))("ab")
   let assert [TooShort(3)] = non_empty_list.to_list(nel)
 }
+
+pub fn min_length_exact_boundary_test() {
+  let assert Valid("abc") = rules.min_length(3, TooShort(3))("abc")
+  let assert Invalid(_) = rules.min_length(3, TooShort(3))("ab")
+}
+
+pub fn min_length_zero_test() {
+  let assert Valid("") = rules.min_length(0, TooShort(0))("")
+}
+
+pub fn min_length_empty_string_test() {
+  let assert Invalid(_) = rules.min_length(1, TooShort(1))("")
+}
+
+// --- max_length ---
 
 pub fn max_length_pass_test() {
   let assert Valid("abc") = rules.max_length(5, TooLong(5))("abc")
@@ -50,6 +74,17 @@ pub fn max_length_fail_test() {
   let assert [TooLong(2)] = non_empty_list.to_list(nel)
 }
 
+pub fn max_length_exact_boundary_test() {
+  let assert Valid("abc") = rules.max_length(3, TooLong(3))("abc")
+  let assert Invalid(_) = rules.max_length(3, TooLong(3))("abcd")
+}
+
+pub fn max_length_empty_string_test() {
+  let assert Valid("") = rules.max_length(0, TooLong(0))("")
+}
+
+// --- min_int ---
+
 pub fn min_int_pass_test() {
   let assert Valid(10) = rules.min_int(0, TooSmall(0))(10)
 }
@@ -58,6 +93,18 @@ pub fn min_int_fail_test() {
   let assert Invalid(nel) = rules.min_int(0, TooSmall(0))(-1)
   let assert [TooSmall(0)] = non_empty_list.to_list(nel)
 }
+
+pub fn min_int_exact_boundary_test() {
+  let assert Valid(0) = rules.min_int(0, TooSmall(0))(0)
+  let assert Invalid(_) = rules.min_int(0, TooSmall(0))(-1)
+}
+
+pub fn min_int_negative_boundary_test() {
+  let assert Valid(-10) = rules.min_int(-10, TooSmall(-10))(-10)
+  let assert Invalid(_) = rules.min_int(-10, TooSmall(-10))(-11)
+}
+
+// --- max_int ---
 
 pub fn max_int_pass_test() {
   let assert Valid(5) = rules.max_int(10, TooBig(10))(5)
@@ -68,6 +115,13 @@ pub fn max_int_fail_test() {
   let assert [TooBig(10)] = non_empty_list.to_list(nel)
 }
 
+pub fn max_int_exact_boundary_test() {
+  let assert Valid(10) = rules.max_int(10, TooBig(10))(10)
+  let assert Invalid(_) = rules.max_int(10, TooBig(10))(11)
+}
+
+// --- one_of ---
+
 pub fn one_of_pass_test() {
   let assert Valid("a") = rules.one_of(["a", "b", "c"], NotAllowed)("a")
 }
@@ -77,6 +131,17 @@ pub fn one_of_fail_test() {
   let assert [NotAllowed] = non_empty_list.to_list(nel)
 }
 
+pub fn one_of_empty_list_always_fails_test() {
+  let assert Invalid(_) = rules.one_of([], NotAllowed)("anything")
+}
+
+pub fn one_of_int_test() {
+  let assert Valid(1) = rules.one_of([1, 2, 3], NotAllowed)(1)
+  let assert Invalid(_) = rules.one_of([1, 2, 3], NotAllowed)(4)
+}
+
+// --- equals ---
+
 pub fn equals_pass_test() {
   let assert Valid(42) = rules.equals(42, NotEqual)(42)
 }
@@ -84,4 +149,44 @@ pub fn equals_pass_test() {
 pub fn equals_fail_test() {
   let assert Invalid(nel) = rules.equals(42, NotEqual)(99)
   let assert [NotEqual] = non_empty_list.to_list(nel)
+}
+
+pub fn equals_string_test() {
+  let assert Valid("yes") = rules.equals("yes", NotEqual)("yes")
+  let assert Invalid(_) = rules.equals("yes", NotEqual)("no")
+}
+
+// --- rules combined with validator combinators ---
+
+pub fn min_max_length_combined_test() {
+  let v =
+    rules.min_length(3, TooShort(3))
+    |> validator.both(rules.max_length(10, TooLong(10)))
+  let assert Valid("hello") = v("hello")
+  let assert Invalid(nel) = v("ab")
+  let assert [TooShort(3)] = non_empty_list.to_list(nel)
+  let assert Invalid(nel2) = v("abcdefghijk")
+  let assert [TooLong(10)] = non_empty_list.to_list(nel2)
+}
+
+pub fn min_max_int_combined_test() {
+  let v =
+    rules.min_int(0, TooSmall(0))
+    |> validator.both(rules.max_int(100, TooBig(100)))
+  let assert Valid(50) = v(50)
+  let assert Invalid(nel) = v(-1)
+  let assert [TooSmall(0)] = non_empty_list.to_list(nel)
+  let assert Invalid(nel2) = v(101)
+  let assert [TooBig(100)] = non_empty_list.to_list(nel2)
+}
+
+pub fn not_empty_guard_min_length_test() {
+  let v =
+    rules.not_empty(IsEmpty)
+    |> validator.guard(rules.min_length(3, TooShort(3)))
+  let assert Invalid(nel) = v("")
+  let assert [IsEmpty] = non_empty_list.to_list(nel)
+  let assert Invalid(nel2) = v("ab")
+  let assert [TooShort(3)] = non_empty_list.to_list(nel2)
+  let assert Valid("abc") = v("abc")
 }

--- a/test/dataprep/validated_test.gleam
+++ b/test/dataprep/validated_test.gleam
@@ -1,5 +1,8 @@
 import dataprep/non_empty_list.{NonEmptyList}
 import dataprep/validated.{Invalid, Valid}
+import gleam/int
+
+// --- map ---
 
 pub fn map_valid_test() {
   let result = Valid(2) |> validated.map(fn(x) { x * 3 })
@@ -11,6 +14,13 @@ pub fn map_invalid_test() {
     Invalid(non_empty_list.single("err")) |> validated.map(fn(x) { x * 3 })
   let assert Invalid(NonEmptyList(first: "err", rest: [])) = result
 }
+
+pub fn map_type_change_test() {
+  let result = Valid(42) |> validated.map(int.to_string)
+  let assert Valid("42") = result
+}
+
+// --- map_error ---
 
 pub fn map_error_valid_test() {
   let result =
@@ -25,6 +35,16 @@ pub fn map_error_invalid_test() {
   let assert Invalid(NonEmptyList(first: "wrapped: bad", rest: [])) = result
 }
 
+pub fn map_error_multiple_errors_test() {
+  let result =
+    Invalid(NonEmptyList(first: "a", rest: ["b"]))
+    |> validated.map_error(fn(e) { "x:" <> e })
+  let assert Invalid(nel) = result
+  let assert ["x:a", "x:b"] = non_empty_list.to_list(nel)
+}
+
+// --- and_then ---
+
 pub fn and_then_valid_test() {
   let result =
     Valid(10)
@@ -37,6 +57,18 @@ pub fn and_then_valid_test() {
   let assert Valid(10) = result
 }
 
+pub fn and_then_valid_to_invalid_test() {
+  let result =
+    Valid(3)
+    |> validated.and_then(fn(x) {
+      case x > 5 {
+        True -> Valid(x)
+        False -> Invalid(non_empty_list.single("too small"))
+      }
+    })
+  let assert Invalid(NonEmptyList(first: "too small", rest: [])) = result
+}
+
 pub fn and_then_short_circuits_test() {
   let result =
     Invalid(non_empty_list.single("first"))
@@ -45,6 +77,51 @@ pub fn and_then_short_circuits_test() {
     })
   let assert Invalid(NonEmptyList(first: "first", rest: [])) = result
 }
+
+pub fn and_then_type_change_test() {
+  let result =
+    Valid("42")
+    |> validated.and_then(fn(s) {
+      case int.parse(s) {
+        Ok(n) -> Valid(n)
+        Error(_) -> Invalid(non_empty_list.single("not an int"))
+      }
+    })
+  let assert Valid(42) = result
+}
+
+pub fn and_then_chained_test() {
+  let result =
+    Valid("10")
+    |> validated.and_then(fn(s) {
+      case int.parse(s) {
+        Ok(n) -> Valid(n)
+        Error(_) -> Invalid(non_empty_list.single("parse"))
+      }
+    })
+    |> validated.and_then(fn(n) {
+      case n > 0 {
+        True -> Valid(n)
+        False -> Invalid(non_empty_list.single("positive"))
+      }
+    })
+  let assert Valid(10) = result
+}
+
+pub fn and_then_does_not_accumulate_test() {
+  // and_then is monadic: first failure stops, second is not run
+  let result =
+    Valid("abc")
+    |> validated.and_then(fn(_) {
+      Invalid(non_empty_list.single("parse failed"))
+    })
+    |> validated.and_then(fn(_) {
+      panic as "should not be called after first and_then fails"
+    })
+  let assert Invalid(NonEmptyList(first: "parse failed", rest: [])) = result
+}
+
+// --- from_result / to_result ---
 
 pub fn from_result_ok_test() {
   let assert Valid(42) = validated.from_result(Ok(42))
@@ -64,6 +141,17 @@ pub fn to_result_invalid_test() {
     validated.to_result(Invalid(NonEmptyList(first: "a", rest: ["b"])))
 }
 
+pub fn from_result_to_result_roundtrip_ok_test() {
+  let assert Ok(99) = Ok(99) |> validated.from_result |> validated.to_result
+}
+
+pub fn from_result_to_result_roundtrip_error_test() {
+  let assert Error(["e"]) =
+    Error("e") |> validated.from_result |> validated.to_result
+}
+
+// --- map2 ---
+
 pub fn map2_all_valid_test() {
   let result = validated.map2(fn(a, b) { a + b }, Valid(1), Valid(2))
   let assert Valid(3) = result
@@ -80,7 +168,17 @@ pub fn map2_accumulates_errors_test() {
   let assert ["e1", "e2"] = non_empty_list.to_list(nel)
 }
 
-pub fn map2_one_invalid_test() {
+pub fn map2_first_invalid_test() {
+  let result =
+    validated.map2(
+      fn(a, b) { a + b },
+      Invalid(non_empty_list.single("e1")),
+      Valid(2),
+    )
+  let assert Invalid(NonEmptyList(first: "e1", rest: [])) = result
+}
+
+pub fn map2_second_invalid_test() {
   let result =
     validated.map2(
       fn(a, b) { a + b },
@@ -89,6 +187,19 @@ pub fn map2_one_invalid_test() {
     )
   let assert Invalid(NonEmptyList(first: "e2", rest: [])) = result
 }
+
+pub fn map2_multiple_errors_per_branch_test() {
+  let result =
+    validated.map2(
+      fn(a, b) { a + b },
+      Invalid(NonEmptyList(first: "e1a", rest: ["e1b"])),
+      Invalid(non_empty_list.single("e2")),
+    )
+  let assert Invalid(nel) = result
+  let assert ["e1a", "e1b", "e2"] = non_empty_list.to_list(nel)
+}
+
+// --- map3 ---
 
 pub type Triple {
   Triple(a: Int, b: Int, c: Int)
@@ -110,6 +221,31 @@ pub fn map3_accumulates_errors_test() {
   let assert Invalid(nel) = result
   let assert ["e1", "e3"] = non_empty_list.to_list(nel)
 }
+
+pub fn map3_all_invalid_test() {
+  let result =
+    validated.map3(
+      Triple,
+      Invalid(non_empty_list.single("e1")),
+      Invalid(non_empty_list.single("e2")),
+      Invalid(non_empty_list.single("e3")),
+    )
+  let assert Invalid(nel) = result
+  let assert ["e1", "e2", "e3"] = non_empty_list.to_list(nel)
+}
+
+pub fn map3_one_invalid_test() {
+  let result =
+    validated.map3(
+      Triple,
+      Valid(1),
+      Invalid(non_empty_list.single("e2")),
+      Valid(3),
+    )
+  let assert Invalid(NonEmptyList(first: "e2", rest: [])) = result
+}
+
+// --- map4 ---
 
 pub type Quad {
   Quad(a: Int, b: Int, c: Int, d: Int)
@@ -133,6 +269,21 @@ pub fn map4_accumulates_errors_test() {
   let assert ["e1", "e2", "e3", "e4"] = non_empty_list.to_list(nel)
 }
 
+pub fn map4_partial_invalid_test() {
+  let result =
+    validated.map4(
+      Quad,
+      Valid(1),
+      Invalid(non_empty_list.single("e2")),
+      Valid(3),
+      Invalid(non_empty_list.single("e4")),
+    )
+  let assert Invalid(nel) = result
+  let assert ["e2", "e4"] = non_empty_list.to_list(nel)
+}
+
+// --- map5 ---
+
 pub type Quint {
   Quint(a: Int, b: Int, c: Int, d: Int, e: Int)
 }
@@ -155,4 +306,56 @@ pub fn map5_accumulates_errors_test() {
     )
   let assert Invalid(nel) = result
   let assert ["e1", "e3", "e5"] = non_empty_list.to_list(nel)
+}
+
+pub fn map5_all_invalid_test() {
+  let result =
+    validated.map5(
+      Quint,
+      Invalid(non_empty_list.single("e1")),
+      Invalid(non_empty_list.single("e2")),
+      Invalid(non_empty_list.single("e3")),
+      Invalid(non_empty_list.single("e4")),
+      Invalid(non_empty_list.single("e5")),
+    )
+  let assert Invalid(nel) = result
+  let assert ["e1", "e2", "e3", "e4", "e5"] = non_empty_list.to_list(nel)
+}
+
+pub fn map5_single_invalid_test() {
+  let result =
+    validated.map5(
+      Quint,
+      Valid(1),
+      Valid(2),
+      Valid(3),
+      Invalid(non_empty_list.single("e4")),
+      Valid(5),
+    )
+  let assert Invalid(NonEmptyList(first: "e4", rest: [])) = result
+}
+
+// --- error order preservation across mapN ---
+
+pub fn map2_error_order_test() {
+  let result =
+    validated.map2(
+      fn(a, b) { #(a, b) },
+      Invalid(NonEmptyList(first: "first", rest: ["second"])),
+      Invalid(non_empty_list.single("third")),
+    )
+  let assert Invalid(nel) = result
+  let assert ["first", "second", "third"] = non_empty_list.to_list(nel)
+}
+
+pub fn map3_error_order_test() {
+  let result =
+    validated.map3(
+      Triple,
+      Invalid(non_empty_list.single("a")),
+      Invalid(non_empty_list.single("b")),
+      Invalid(non_empty_list.single("c")),
+    )
+  let assert Invalid(nel) = result
+  let assert ["a", "b", "c"] = non_empty_list.to_list(nel)
 }

--- a/test/dataprep/validator_test.gleam
+++ b/test/dataprep/validator_test.gleam
@@ -12,6 +12,8 @@ pub type Err {
   FieldError(path: String, detail: Err)
 }
 
+// --- check ---
+
 pub fn check_ok_test() {
   let v = validator.check(fn(_) { Ok(Nil) })
   let assert Valid("anything") = v("anything")
@@ -28,6 +30,24 @@ pub fn check_error_test() {
   let assert Invalid(_) = v("ab")
 }
 
+pub fn check_value_dependent_error_test() {
+  let v =
+    validator.check(fn(s: String) {
+      case string.length(s) {
+        0 -> Error(IsEmpty)
+        n if n < 3 -> Error(TooShort)
+        _ -> Ok(Nil)
+      }
+    })
+  let assert Invalid(nel) = v("")
+  let assert [IsEmpty] = non_empty_list.to_list(nel)
+  let assert Invalid(nel2) = v("ab")
+  let assert [TooShort] = non_empty_list.to_list(nel2)
+  let assert Valid("abc") = v("abc")
+}
+
+// --- predicate ---
+
 pub fn predicate_pass_test() {
   let v = validator.predicate(fn(n: Int) { n > 0 }, TooShort)
   let assert Valid(5) = v(5)
@@ -37,6 +57,14 @@ pub fn predicate_fail_test() {
   let v = validator.predicate(fn(n: Int) { n > 0 }, TooShort)
   let assert Invalid(_) = v(-1)
 }
+
+pub fn predicate_boundary_test() {
+  let v = validator.predicate(fn(n: Int) { n > 0 }, TooShort)
+  let assert Invalid(_) = v(0)
+  let assert Valid(1) = v(1)
+}
+
+// --- both ---
 
 pub fn both_all_pass_test() {
   let v =
@@ -56,9 +84,58 @@ pub fn both_accumulates_errors_test() {
   let assert [TooShort, TooLong] = non_empty_list.to_list(nel)
 }
 
+pub fn both_first_fails_only_test() {
+  let v =
+    validator.predicate(fn(_: String) { False }, TooShort)
+    |> validator.both(validator.predicate(fn(_) { True }, TooLong))
+  let assert Invalid(nel) = v("x")
+  let assert [TooShort] = non_empty_list.to_list(nel)
+}
+
+pub fn both_second_fails_only_test() {
+  let v =
+    validator.predicate(fn(_: String) { True }, TooShort)
+    |> validator.both(validator.predicate(fn(_) { False }, TooLong))
+  let assert Invalid(nel) = v("x")
+  let assert [TooLong] = non_empty_list.to_list(nel)
+}
+
+pub fn both_preserves_input_value_test() {
+  let v =
+    validator.predicate(fn(s: String) { s != "" }, IsEmpty)
+    |> validator.both(validator.predicate(
+      fn(s) { string.length(s) <= 10 },
+      TooLong,
+    ))
+  let assert Valid(result) = v("test")
+  let assert "test" = result
+}
+
+pub fn both_chained_three_test() {
+  let v =
+    validator.predicate(fn(_: String) { False }, IsEmpty)
+    |> validator.both(validator.predicate(fn(_) { False }, TooShort))
+    |> validator.both(validator.predicate(fn(_) { False }, TooLong))
+  let assert Invalid(nel) = v("x")
+  let assert [IsEmpty, TooShort, TooLong] = non_empty_list.to_list(nel)
+}
+
+// --- all ---
+
 pub fn all_empty_validators_test() {
   let v = validator.all([])
   let assert Valid("anything") = v("anything")
+}
+
+pub fn all_single_pass_test() {
+  let v = validator.all([validator.predicate(fn(_: String) { True }, IsEmpty)])
+  let assert Valid("x") = v("x")
+}
+
+pub fn all_single_fail_test() {
+  let v = validator.all([validator.predicate(fn(_: String) { False }, IsEmpty)])
+  let assert Invalid(nel) = v("x")
+  let assert [IsEmpty] = non_empty_list.to_list(nel)
 }
 
 pub fn all_accumulates_test() {
@@ -71,6 +148,28 @@ pub fn all_accumulates_test() {
   let assert Invalid(nel) = v("x")
   let assert [TooShort, TooLong] = non_empty_list.to_list(nel)
 }
+
+pub fn all_all_fail_test() {
+  let v =
+    validator.all([
+      validator.predicate(fn(_: String) { False }, IsEmpty),
+      validator.predicate(fn(_: String) { False }, TooShort),
+      validator.predicate(fn(_: String) { False }, TooLong),
+    ])
+  let assert Invalid(nel) = v("x")
+  let assert [IsEmpty, TooShort, TooLong] = non_empty_list.to_list(nel)
+}
+
+pub fn all_all_pass_test() {
+  let v =
+    validator.all([
+      validator.predicate(fn(_: String) { True }, IsEmpty),
+      validator.predicate(fn(_: String) { True }, TooShort),
+    ])
+  let assert Valid("x") = v("x")
+}
+
+// --- alt ---
 
 pub fn alt_first_succeeds_skips_second_test() {
   let v =
@@ -95,6 +194,25 @@ pub fn alt_both_fail_accumulates_test() {
   let assert Invalid(nel) = v("test")
   let assert [NotUuid, NotSlug] = non_empty_list.to_list(nel)
 }
+
+pub fn alt_chained_three_first_wins_test() {
+  let v =
+    validator.predicate(fn(_: String) { False }, IsEmpty)
+    |> validator.alt(validator.predicate(fn(_) { True }, TooShort))
+    |> validator.alt(fn(_) { panic as "third alt branch should not run" })
+  let assert Valid("x") = v("x")
+}
+
+pub fn alt_chained_three_all_fail_test() {
+  let v =
+    validator.predicate(fn(_: String) { False }, IsEmpty)
+    |> validator.alt(validator.predicate(fn(_) { False }, TooShort))
+    |> validator.alt(validator.predicate(fn(_) { False }, TooLong))
+  let assert Invalid(nel) = v("x")
+  let assert [IsEmpty, TooShort, TooLong] = non_empty_list.to_list(nel)
+}
+
+// --- guard ---
 
 pub fn guard_pre_fails_skips_main_test() {
   let v =
@@ -124,6 +242,36 @@ pub fn guard_both_pass_test() {
   let assert Valid("hello") = v("hello")
 }
 
+pub fn guard_does_not_accumulate_test() {
+  // guard is short-circuit, NOT accumulation
+  // when pre fails, we only see pre's error, not main's
+  let v =
+    validator.predicate(fn(_: String) { False }, IsEmpty)
+    |> validator.guard(validator.predicate(fn(_) { False }, TooShort))
+  let assert Invalid(nel) = v("x")
+  let assert [IsEmpty] = non_empty_list.to_list(nel)
+}
+
+pub fn guard_chained_test() {
+  // guard(non_empty, guard(min_length, max_length))
+  let v =
+    validator.predicate(fn(s: String) { s != "" }, IsEmpty)
+    |> validator.guard(
+      validator.predicate(fn(s: String) { string.length(s) >= 3 }, TooShort)
+      |> validator.guard(validator.predicate(
+        fn(s) { string.length(s) <= 10 },
+        TooLong,
+      )),
+    )
+  let assert Invalid(nel) = v("")
+  let assert [IsEmpty] = non_empty_list.to_list(nel)
+  let assert Invalid(nel2) = v("ab")
+  let assert [TooShort] = non_empty_list.to_list(nel2)
+  let assert Valid("abc") = v("abc")
+}
+
+// --- map_error ---
+
 pub fn map_error_test() {
   let v =
     validator.predicate(fn(_: String) { False }, TooShort)
@@ -132,10 +280,85 @@ pub fn map_error_test() {
   let assert [FieldError("name", TooShort)] = non_empty_list.to_list(nel)
 }
 
+pub fn map_error_valid_passes_through_test() {
+  let v =
+    validator.predicate(fn(_: String) { True }, TooShort)
+    |> validator.map_error(fn(e) { FieldError("name", e) })
+  let assert Valid("x") = v("x")
+}
+
+pub fn map_error_multiple_errors_test() {
+  let v =
+    validator.predicate(fn(_: String) { False }, TooShort)
+    |> validator.both(validator.predicate(fn(_) { False }, TooLong))
+    |> validator.map_error(fn(e) { FieldError("field", e) })
+  let assert Invalid(nel) = v("x")
+  let assert [FieldError("field", TooShort), FieldError("field", TooLong)] =
+    non_empty_list.to_list(nel)
+}
+
+// --- label ---
+
 pub fn label_test() {
   let v =
     validator.predicate(fn(_: String) { False }, TooShort)
     |> validator.label("user.name", FieldError)
   let assert Invalid(nel) = v("x")
   let assert [FieldError("user.name", TooShort)] = non_empty_list.to_list(nel)
+}
+
+pub fn label_valid_passes_through_test() {
+  let v =
+    validator.predicate(fn(_: String) { True }, TooShort)
+    |> validator.label("user.name", FieldError)
+  let assert Valid("x") = v("x")
+}
+
+pub fn label_multiple_errors_test() {
+  let v =
+    validator.predicate(fn(_: String) { False }, IsEmpty)
+    |> validator.both(validator.predicate(fn(_) { False }, TooShort))
+    |> validator.label("email", FieldError)
+  let assert Invalid(nel) = v("x")
+  let assert [FieldError("email", IsEmpty), FieldError("email", TooShort)] =
+    non_empty_list.to_list(nel)
+}
+
+// --- composition: both + alt + guard ---
+
+pub fn both_then_alt_test() {
+  // v1: must be non-empty AND short
+  // v2: must be non-empty AND long
+  // alt: either form is ok
+  let short =
+    validator.predicate(fn(s: String) { s != "" }, IsEmpty)
+    |> validator.both(validator.predicate(
+      fn(s) { string.length(s) <= 3 },
+      TooLong,
+    ))
+  let long =
+    validator.predicate(fn(s: String) { s != "" }, IsEmpty)
+    |> validator.both(validator.predicate(
+      fn(s) { string.length(s) >= 10 },
+      TooShort,
+    ))
+  let v = validator.alt(short, long)
+
+  let assert Valid("ab") = v("ab")
+  let assert Valid("abcdefghijk") = v("abcdefghijk")
+}
+
+pub fn guard_then_both_test() {
+  let v =
+    validator.predicate(fn(s: String) { s != "" }, IsEmpty)
+    |> validator.guard(
+      validator.predicate(fn(s: String) { string.length(s) >= 3 }, TooShort)
+      |> validator.both(validator.predicate(
+        fn(s) { string.length(s) <= 10 },
+        TooLong,
+      )),
+    )
+  let assert Invalid(nel) = v("")
+  let assert [IsEmpty] = non_empty_list.to_list(nel)
+  let assert Valid("hello") = v("hello")
 }


### PR DESCRIPTION
## Summary
- Expand test suite from 73 to 155 tests: boundary values, short-circuit panic sentinels, error accumulation order, combinator composition across all five modules
- Add three practical examples to README: field validation with label, parse-then-validate with and_then, nested error labeling with map3
- Add four recipe documents: signup form, query params, CSV row, API payload
- Fix missing imports in all code samples so they compile as-is
- Fix empty slug bug in api_payload recipe (is_slug + not_empty guard)
- Use absolute GitHub URLs for README links and logo (HexDocs compatibility)
- Document intentional assert usage in collapse_space (fixed regex pattern)
- Add release.yml workflow for automatic Hex publish on v* tag push

## Test plan
- [x] `just ci` passes (155 tests, format check, build with warnings-as-errors)
- [ ] Verify README renders correctly on GitHub
- [ ] Verify logo and links work in HexDocs after publish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated release workflow to publish tagged releases

* **Documentation**
  * Added four new validation recipes (signup form, API payload, CSV row, query params)
  * Expanded README with examples, updated image source and contributing/license links

* **Tests**
  * Large expansion of test coverage across validators, preprocessing helpers, validated combinators, and non-empty list utilities

* **Docs**
  * Clarified prep utility documentation comment on space-collapsing behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->