### PR TITLE
chore(ci): add strict glinter checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,44 +12,48 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: extractions/setup-just@v3
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "27"
           gleam-version: "1.15"
-      - run: gleam format --check
+      - run: just format-check
 
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: extractions/setup-just@v3
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "27"
           gleam-version: "1.15"
-      - run: gleam deps download
-      - run: gleam build --warnings-as-errors
+      - run: just deps
+      - run: just lint
 
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: extractions/setup-just@v3
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "27"
           gleam-version: "1.15"
-      - run: gleam deps download
-      - run: gleam build
+      - run: just deps
+      - run: just build
 
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: extractions/setup-just@v3
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "27"
           gleam-version: "1.15"
-      - run: gleam deps download
-      - run: gleam test
+      - run: just deps
+      - run: just test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: extractions/setup-just@v3
+
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "27"
           gleam-version: "1.15"
 
-      - run: gleam deps download
-      - run: gleam format --check
-      - run: gleam build --warnings-as-errors
-      - run: gleam test
+      - run: just ci
       - run: echo 'I am not using semantic versioning' | gleam publish -y
         env:
           HEXPM_API_KEY: ${{ secrets.HEXPM_API_KEY }}

--- a/gleam.toml
+++ b/gleam.toml
@@ -11,3 +11,47 @@ gleam_regexp = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
+glinter = ">= 2.14.0 and < 3.0.0"
+
+[tools.glinter]
+warnings_as_errors = true
+include = ["src/", "test/"]
+
+[tools.glinter.rules]
+assert_ok_pattern = "error"
+avoid_panic = "error"
+avoid_todo = "error"
+deep_nesting = "error"
+discarded_result = "error"
+division_by_zero = "error"
+duplicate_import = "error"
+echo = "error"
+error_context_lost = "error"
+ffi_usage = "error"
+function_complexity = "error"
+label_possible = "error"
+missing_labels = "error"
+missing_type_annotation = "error"
+module_complexity = "error"
+panic_without_message = "error"
+prefer_guard_clause = "error"
+redundant_case = "error"
+short_variable_name = "error"
+string_inspect = "error"
+stringly_typed_error = "error"
+thrown_away_error = "error"
+todo_without_message = "error"
+trailing_underscore = "error"
+unnecessary_string_concatenation = "error"
+unnecessary_variable = "error"
+unqualified_import = "error"
+unused_exports = "error"
+unwrap_used = "error"
+
+[tools.glinter.ignore]
+"test/**/*.gleam" = [
+  "assert_ok_pattern",
+  "missing_type_annotation",
+  "short_variable_name",
+  "unused_exports",
+]

--- a/gleam.toml
+++ b/gleam.toml
@@ -49,9 +49,4 @@ unused_exports = "error"
 unwrap_used = "error"
 
 [tools.glinter.ignore]
-"test/**/*.gleam" = [
-  "assert_ok_pattern",
-  "missing_type_annotation",
-  "short_variable_name",
-  "unused_exports",
-]
+"test/**/*.gleam" = ["unused_exports"]

--- a/justfile
+++ b/justfile
@@ -15,6 +15,9 @@ format-check:
 typecheck:
   gleam check
 
+lint:
+  gleam run -m glinter
+
 build:
   gleam build --warnings-as-errors
 
@@ -26,6 +29,7 @@ docs:
 
 check:
   gleam format --check .
+  gleam run -m glinter
   gleam check
   gleam build --warnings-as-errors
   gleam test

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,12 +2,23 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
+  { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "0.71.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "702F3BC2A14793906880B1078B19A6165F87323AEE8D0C4A34085846336FCAAE" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
   { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
+  { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
+  { name = "glinter", version = "2.14.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "F4FA6B575FA9ED293B3BCCCEA4ED2612EAFC8AAB4305638DB5680FFF84C6972B" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
+  { name = "tom", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "234A842F3D087D35737483F5DFB6DE9839E3366EF0CAF8726D2D094210227670" },
 ]
 
 [requirements]
 gleam_regexp = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
+glinter = { version = ">= 2.14.0 and < 3.0.0" }

--- a/src/dataprep/non_empty_list.gleam
+++ b/src/dataprep/non_empty_list.gleam
@@ -10,12 +10,15 @@ pub fn single(value: a) -> NonEmptyList(a) {
 }
 
 /// Prepend an element to a NonEmptyList.
-pub fn cons(head: a, tail: NonEmptyList(a)) -> NonEmptyList(a) {
+pub fn cons(head head: a, tail tail: NonEmptyList(a)) -> NonEmptyList(a) {
   NonEmptyList(first: head, rest: [tail.first, ..tail.rest])
 }
 
 /// Concatenate two NonEmptyLists.
-pub fn append(left: NonEmptyList(a), right: NonEmptyList(a)) -> NonEmptyList(a) {
+pub fn append(
+  left left: NonEmptyList(a),
+  right right: NonEmptyList(a),
+) -> NonEmptyList(a) {
   NonEmptyList(
     first: left.first,
     rest: list.append(left.rest, [right.first, ..right.rest]),
@@ -24,7 +27,9 @@ pub fn append(left: NonEmptyList(a), right: NonEmptyList(a)) -> NonEmptyList(a) 
 
 /// Flatten a NonEmptyList of NonEmptyLists into a single NonEmptyList.
 pub fn concat(lists: NonEmptyList(NonEmptyList(a))) -> NonEmptyList(a) {
-  list.fold(over: lists.rest, from: lists.first, with: append)
+  list.fold(over: lists.rest, from: lists.first, with: fn(acc, next) {
+    append(left: acc, right: next)
+  })
 }
 
 /// Transform every element.

--- a/src/dataprep/parse.gleam
+++ b/src/dataprep/parse.gleam
@@ -15,7 +15,7 @@ import gleam/int
 pub fn int(raw: String, on_error: fn(String) -> e) -> Validated(Int, e) {
   case int.parse(raw) {
     Ok(n) -> Valid(n)
-    Error(_) -> Invalid(non_empty_list.single(on_error(raw)))
+    Error(Nil) -> Invalid(non_empty_list.single(on_error(raw)))
   }
 }
 
@@ -28,6 +28,6 @@ pub fn int(raw: String, on_error: fn(String) -> e) -> Validated(Int, e) {
 pub fn float(raw: String, on_error: fn(String) -> e) -> Validated(Float, e) {
   case float.parse(raw) {
     Ok(x) -> Valid(x)
-    Error(_) -> Invalid(non_empty_list.single(on_error(raw)))
+    Error(Nil) -> Invalid(non_empty_list.single(on_error(raw)))
   }
 }

--- a/src/dataprep/prep.gleam
+++ b/src/dataprep/prep.gleam
@@ -8,7 +8,7 @@ pub type Prep(a) =
   fn(a) -> a
 
 /// Sequential composition: apply p1, then apply p2 to the result.
-pub fn then(p1: Prep(a), p2: Prep(a)) -> Prep(a) {
+pub fn then(first p1: Prep(a), next p2: Prep(a)) -> Prep(a) {
   fn(x) { p2(p1(x)) }
 }
 
@@ -16,7 +16,7 @@ pub fn then(p1: Prep(a), p2: Prep(a)) -> Prep(a) {
 /// Empty list returns identity.
 pub fn sequence(steps: List(Prep(a))) -> Prep(a) {
   list.fold(over: steps, from: identity(), with: fn(acc, step) {
-    then(acc, step)
+    then(first: acc, next: step)
   })
 }
 
@@ -46,12 +46,16 @@ pub fn uppercase() -> Prep(String) {
 /// a fixed, known-valid regular expression, so compilation cannot fail
 /// at runtime. The assert is intentional and safe.
 pub fn collapse_space() -> Prep(String) {
+  // nolint: assert_ok_pattern -- "\\s+" is a fixed, known-valid regex literal
   let assert Ok(re) = regexp.from_string("\\s+")
   fn(s) { regexp.replace(each: re, in: s, with: " ") }
 }
 
 /// Replace all occurrences of target with replacement.
-pub fn replace(target: String, replacement: String) -> Prep(String) {
+pub fn replace(
+  target target: String,
+  replacement replacement: String,
+) -> Prep(String) {
   fn(s) { string.replace(in: s, each: target, with: replacement) }
 }
 
@@ -61,7 +65,7 @@ pub fn replace(target: String, replacement: String) -> Prep(String) {
 /// inputs like "  " are NOT treated as empty. If you want
 /// whitespace-only values to trigger the default, compose with trim:
 ///
-///   prep.trim() |> prep.then(prep.default("N/A"))
+///   prep.trim() |> prep.then(first: _, next: prep.default("N/A"))
 pub fn default(fallback: String) -> Prep(String) {
   fn(s) {
     case s {

--- a/src/dataprep/rules.gleam
+++ b/src/dataprep/rules.gleam
@@ -27,24 +27,31 @@ pub fn not_blank(error: e) -> Validator(String, e) {
 ///
 /// Example:
 ///   let assert Ok(re) = regexp.from_string("^[a-z]+$")
-///   rules.matches(re, InvalidFormat)
+///   rules.matches(pattern: re, error: InvalidFormat)
 ///
-pub fn matches(re: regexp.Regexp, error: e) -> Validator(String, e) {
+pub fn matches(
+  pattern re: regexp.Regexp,
+  error error: e,
+) -> Validator(String, e) {
   validator.predicate(fn(s) { regexp.check(re, s) }, error)
 }
 
 /// Fails if the string length is less than min.
-pub fn min_length(min: Int, error: e) -> Validator(String, e) {
+pub fn min_length(minimum min: Int, error error: e) -> Validator(String, e) {
   validator.predicate(fn(s) { string.length(s) >= min }, error)
 }
 
 /// Fails if the string length exceeds max.
-pub fn max_length(max: Int, error: e) -> Validator(String, e) {
+pub fn max_length(maximum max: Int, error error: e) -> Validator(String, e) {
   validator.predicate(fn(s) { string.length(s) <= max }, error)
 }
 
 /// Fails if the string length is outside [min, max].
-pub fn length_between(min: Int, max: Int, error: e) -> Validator(String, e) {
+pub fn length_between(
+  minimum min: Int,
+  maximum max: Int,
+  error error: e,
+) -> Validator(String, e) {
   validator.predicate(
     fn(s) {
       let len = string.length(s)
@@ -55,22 +62,22 @@ pub fn length_between(min: Int, max: Int, error: e) -> Validator(String, e) {
 }
 
 /// Fails if the int is less than min.
-pub fn min_int(min: Int, error: e) -> Validator(Int, e) {
+pub fn min_int(minimum min: Int, error error: e) -> Validator(Int, e) {
   validator.predicate(fn(n) { n >= min }, error)
 }
 
 /// Fails if the int exceeds max.
-pub fn max_int(max: Int, error: e) -> Validator(Int, e) {
+pub fn max_int(maximum max: Int, error error: e) -> Validator(Int, e) {
   validator.predicate(fn(n) { n <= max }, error)
 }
 
 /// Fails if the float is less than min.
-pub fn min_float(min: Float, error: e) -> Validator(Float, e) {
+pub fn min_float(minimum min: Float, error error: e) -> Validator(Float, e) {
   validator.predicate(fn(x) { x >=. min }, error)
 }
 
 /// Fails if the float exceeds max.
-pub fn max_float(max: Float, error: e) -> Validator(Float, e) {
+pub fn max_float(maximum max: Float, error error: e) -> Validator(Float, e) {
   validator.predicate(fn(x) { x <=. max }, error)
 }
 
@@ -85,12 +92,12 @@ pub fn non_negative_float(error: e) -> Validator(Float, e) {
 }
 
 /// Fails if the value is not in the allowed list.
-pub fn one_of(allowed: List(a), error: e) -> Validator(a, e) {
+pub fn one_of(allowed allowed: List(a), error error: e) -> Validator(a, e) {
   validator.predicate(fn(a) { list.contains(allowed, a) }, error)
 }
 
 /// Fails if the value does not equal the expected value.
-pub fn equals(expected: a, error: e) -> Validator(a, e) {
+pub fn equals(expected expected: a, error error: e) -> Validator(a, e) {
   validator.predicate(fn(a) { a == expected }, error)
 }
 

--- a/src/dataprep/validated.gleam
+++ b/src/dataprep/validated.gleam
@@ -77,7 +77,8 @@ pub fn map2(
     Valid(a), Valid(b) -> Valid(f(a, b))
     Valid(_), Invalid(eb) -> Invalid(eb)
     Invalid(ea), Valid(_) -> Invalid(ea)
-    Invalid(ea), Invalid(eb) -> Invalid(non_empty_list.append(ea, eb))
+    Invalid(ea), Invalid(eb) ->
+      Invalid(non_empty_list.append(left: ea, right: eb))
   }
 }
 

--- a/src/dataprep/validator.gleam
+++ b/src/dataprep/validator.gleam
@@ -30,13 +30,17 @@ pub fn predicate(condition: fn(a) -> Bool, error: e) -> Validator(a, e) {
 
 /// Run both validators on the same input. Accumulate all errors.
 /// On success, return the (unchanged) input.
-pub fn both(v1: Validator(a, e), v2: Validator(a, e)) -> Validator(a, e) {
+pub fn both(
+  first v1: Validator(a, e),
+  second v2: Validator(a, e),
+) -> Validator(a, e) {
   fn(a) {
     case v1(a), v2(a) {
       Valid(_), Valid(_) -> Valid(a)
       Valid(_), Invalid(e2) -> Invalid(e2)
       Invalid(e1), Valid(_) -> Invalid(e1)
-      Invalid(e1), Invalid(e2) -> Invalid(non_empty_list.append(e1, e2))
+      Invalid(e1), Invalid(e2) ->
+        Invalid(non_empty_list.append(left: e1, right: e2))
     }
   }
 }
@@ -72,14 +76,17 @@ pub fn all(validators: List(Validator(a, e))) -> Validator(a, e) {
 /// The accumulated errors can be noisy for end-user display.
 /// Use `map_error` to tag each branch before `alt`, then
 /// post-process the error list before presenting to users.
-pub fn alt(v1: Validator(a, e), v2: Validator(a, e)) -> Validator(a, e) {
+pub fn alt(
+  first v1: Validator(a, e),
+  second v2: Validator(a, e),
+) -> Validator(a, e) {
   fn(a) {
     case v1(a) {
       Valid(x) -> Valid(x)
       Invalid(e1) ->
         case v2(a) {
           Valid(x) -> Valid(x)
-          Invalid(e2) -> Invalid(non_empty_list.append(e1, e2))
+          Invalid(e2) -> Invalid(non_empty_list.append(left: e1, right: e2))
         }
     }
   }
@@ -92,7 +99,10 @@ pub fn alt(v1: Validator(a, e), v2: Validator(a, e)) -> Validator(a, e) {
 /// Evaluation: pre runs first. If Valid, main runs on the same
 /// input. If pre fails, main is never called and only pre's errors
 /// are returned. Errors are NOT accumulated across pre and main.
-pub fn guard(pre: Validator(a, e), main: Validator(a, e)) -> Validator(a, e) {
+pub fn guard(
+  pre pre: Validator(a, e),
+  main main: Validator(a, e),
+) -> Validator(a, e) {
   fn(a) {
     case pre(a) {
       Valid(_) -> main(a)

--- a/test/dataprep/non_empty_list_test.gleam
+++ b/test/dataprep/non_empty_list_test.gleam
@@ -2,142 +2,143 @@ import dataprep/non_empty_list.{NonEmptyList}
 
 // --- single ---
 
-pub fn single_test() {
-  let nel = non_empty_list.single(1)
-  let assert NonEmptyList(first: 1, rest: []) = nel
+pub fn single_test() -> Nil {
+  assert non_empty_list.single(1) == NonEmptyList(first: 1, rest: [])
 }
 
-pub fn single_string_test() {
-  let nel = non_empty_list.single("a")
-  let assert ["a"] = non_empty_list.to_list(nel)
+pub fn single_string_test() -> Nil {
+  assert non_empty_list.single("a") |> non_empty_list.to_list == ["a"]
 }
 
 // --- cons ---
 
-pub fn cons_test() {
-  let nel = non_empty_list.single(2) |> non_empty_list.cons(head: 1, tail: _)
-  let assert NonEmptyList(first: 1, rest: [2]) = nel
+pub fn cons_test() -> Nil {
+  assert non_empty_list.single(2) |> non_empty_list.cons(head: 1, tail: _)
+    == NonEmptyList(first: 1, rest: [2])
 }
 
-pub fn cons_multiple_test() {
-  let nel =
-    non_empty_list.single(3)
+pub fn cons_multiple_test() -> Nil {
+  assert non_empty_list.single(3)
     |> non_empty_list.cons(head: 2, tail: _)
     |> non_empty_list.cons(head: 1, tail: _)
-  let assert [1, 2, 3] = non_empty_list.to_list(nel)
+    |> non_empty_list.to_list
+    == [1, 2, 3]
 }
 
 // --- append ---
 
-pub fn append_test() {
+pub fn append_test() -> Nil {
   let left = NonEmptyList(first: 1, rest: [2])
   let right = NonEmptyList(first: 3, rest: [4])
-  let result = non_empty_list.append(left: left, right: right)
-  let assert NonEmptyList(first: 1, rest: [2, 3, 4]) = result
+  assert non_empty_list.append(left: left, right: right)
+    == NonEmptyList(first: 1, rest: [2, 3, 4])
 }
 
-pub fn append_single_to_single_test() {
-  let result =
-    non_empty_list.append(
+pub fn append_single_to_single_test() -> Nil {
+  assert non_empty_list.append(
       left: non_empty_list.single(1),
       right: non_empty_list.single(2),
     )
-  let assert [1, 2] = non_empty_list.to_list(result)
+    |> non_empty_list.to_list
+    == [1, 2]
 }
 
-pub fn append_preserves_order_test() {
+pub fn append_preserves_order_test() -> Nil {
   let left = NonEmptyList(first: "a", rest: ["b"])
   let right = NonEmptyList(first: "c", rest: ["d"])
-  let assert ["a", "b", "c", "d"] =
-    non_empty_list.to_list(non_empty_list.append(left: left, right: right))
+  assert non_empty_list.to_list(non_empty_list.append(left: left, right: right))
+    == ["a", "b", "c", "d"]
 }
 
 // --- concat ---
 
-pub fn concat_test() {
-  let a = NonEmptyList(first: 1, rest: [2])
-  let b = NonEmptyList(first: 3, rest: [])
-  let c = NonEmptyList(first: 4, rest: [5])
-  let lists = NonEmptyList(first: a, rest: [b, c])
-  let result = non_empty_list.concat(lists)
-  let assert [1, 2, 3, 4, 5] = non_empty_list.to_list(result)
+pub fn concat_test() -> Nil {
+  let first_group = NonEmptyList(first: 1, rest: [2])
+  let second_group = NonEmptyList(first: 3, rest: [])
+  let third_group = NonEmptyList(first: 4, rest: [5])
+  let groups =
+    NonEmptyList(first: first_group, rest: [second_group, third_group])
+  assert non_empty_list.concat(groups) |> non_empty_list.to_list
+    == [1, 2, 3, 4, 5]
 }
 
-pub fn concat_single_list_test() {
+pub fn concat_single_list_test() -> Nil {
   let inner = NonEmptyList(first: 42, rest: [])
-  let lists = NonEmptyList(first: inner, rest: [])
-  let assert [42] = non_empty_list.to_list(non_empty_list.concat(lists))
+  let groups = NonEmptyList(first: inner, rest: [])
+  assert non_empty_list.concat(groups) |> non_empty_list.to_list == [42]
 }
 
 // --- map ---
 
-pub fn map_test() {
-  let nel = NonEmptyList(first: 1, rest: [2, 3])
-  let result = non_empty_list.map(nel, fn(x) { x * 2 })
-  let assert [2, 4, 6] = non_empty_list.to_list(result)
+pub fn map_test() -> Nil {
+  let values = NonEmptyList(first: 1, rest: [2, 3])
+  assert non_empty_list.map(values, fn(x) { x * 2 }) |> non_empty_list.to_list
+    == [2, 4, 6]
 }
 
-pub fn map_single_test() {
-  let nel = non_empty_list.single(10)
-  let result = non_empty_list.map(nel, fn(x) { x + 1 })
-  let assert [11] = non_empty_list.to_list(result)
+pub fn map_single_test() -> Nil {
+  let value = non_empty_list.single(10)
+  assert non_empty_list.map(value, fn(x) { x + 1 }) |> non_empty_list.to_list
+    == [11]
 }
 
-pub fn map_type_change_test() {
-  let nel = NonEmptyList(first: 1, rest: [2, 3])
-  let result = non_empty_list.map(nel, fn(x) { x > 1 })
-  let assert [False, True, True] = non_empty_list.to_list(result)
+pub fn map_type_change_test() -> Nil {
+  let values = NonEmptyList(first: 1, rest: [2, 3])
+  assert non_empty_list.map(values, fn(x) { x > 1 }) |> non_empty_list.to_list
+    == [False, True, True]
 }
 
 // --- flat_map ---
 
-pub fn flat_map_test() {
-  let nel = NonEmptyList(first: 1, rest: [2])
-  let result =
-    non_empty_list.flat_map(nel, fn(x) {
+pub fn flat_map_test() -> Nil {
+  let values = NonEmptyList(first: 1, rest: [2])
+  assert non_empty_list.flat_map(values, fn(x) {
       NonEmptyList(first: x, rest: [x * 10])
     })
-  let assert [1, 10, 2, 20] = non_empty_list.to_list(result)
+    |> non_empty_list.to_list
+    == [1, 10, 2, 20]
 }
 
-pub fn flat_map_single_test() {
-  let nel = non_empty_list.single(5)
-  let result =
-    non_empty_list.flat_map(nel, fn(x) { NonEmptyList(first: x, rest: [x + 1]) })
-  let assert [5, 6] = non_empty_list.to_list(result)
+pub fn flat_map_single_test() -> Nil {
+  let value = non_empty_list.single(5)
+  assert non_empty_list.flat_map(value, fn(x) {
+      NonEmptyList(first: x, rest: [x + 1])
+    })
+    |> non_empty_list.to_list
+    == [5, 6]
 }
 
 // --- to_list ---
 
-pub fn to_list_test() {
-  let nel = NonEmptyList(first: "a", rest: ["b", "c"])
-  let assert ["a", "b", "c"] = non_empty_list.to_list(nel)
+pub fn to_list_test() -> Nil {
+  let values = NonEmptyList(first: "a", rest: ["b", "c"])
+  assert non_empty_list.to_list(values) == ["a", "b", "c"]
 }
 
-pub fn to_list_single_test() {
-  let assert [42] = non_empty_list.to_list(non_empty_list.single(42))
+pub fn to_list_single_test() -> Nil {
+  assert non_empty_list.single(42) |> non_empty_list.to_list == [42]
 }
 
 // --- from_list ---
 
-pub fn from_list_empty_test() {
-  let assert Error(Nil) = non_empty_list.from_list([])
+pub fn from_list_empty_test() -> Nil {
+  assert non_empty_list.from_list([]) == Error(Nil)
 }
 
-pub fn from_list_non_empty_test() {
-  let assert Ok(nel) = non_empty_list.from_list([1, 2, 3])
-  let assert NonEmptyList(first: 1, rest: [2, 3]) = nel
+pub fn from_list_non_empty_test() -> Nil {
+  assert non_empty_list.from_list([1, 2, 3])
+    == Ok(NonEmptyList(first: 1, rest: [2, 3]))
 }
 
-pub fn from_list_single_element_test() {
-  let assert Ok(nel) = non_empty_list.from_list(["x"])
-  let assert NonEmptyList(first: "x", rest: []) = nel
+pub fn from_list_single_element_test() -> Nil {
+  assert non_empty_list.from_list(["x"])
+    == Ok(NonEmptyList(first: "x", rest: []))
 }
 
 // --- roundtrip ---
 
-pub fn from_list_to_list_roundtrip_test() {
+pub fn from_list_to_list_roundtrip_test() -> Nil {
   let original = [1, 2, 3, 4, 5]
-  let assert Ok(nel) = non_empty_list.from_list(original)
-  let assert [1, 2, 3, 4, 5] = non_empty_list.to_list(nel)
+  assert non_empty_list.from_list(original)
+    == Ok(NonEmptyList(first: 1, rest: [2, 3, 4, 5]))
 }

--- a/test/dataprep/non_empty_list_test.gleam
+++ b/test/dataprep/non_empty_list_test.gleam
@@ -15,15 +15,15 @@ pub fn single_string_test() {
 // --- cons ---
 
 pub fn cons_test() {
-  let nel = non_empty_list.single(2) |> non_empty_list.cons(1, _)
+  let nel = non_empty_list.single(2) |> non_empty_list.cons(head: 1, tail: _)
   let assert NonEmptyList(first: 1, rest: [2]) = nel
 }
 
 pub fn cons_multiple_test() {
   let nel =
     non_empty_list.single(3)
-    |> non_empty_list.cons(2, _)
-    |> non_empty_list.cons(1, _)
+    |> non_empty_list.cons(head: 2, tail: _)
+    |> non_empty_list.cons(head: 1, tail: _)
   let assert [1, 2, 3] = non_empty_list.to_list(nel)
 }
 
@@ -32,13 +32,16 @@ pub fn cons_multiple_test() {
 pub fn append_test() {
   let left = NonEmptyList(first: 1, rest: [2])
   let right = NonEmptyList(first: 3, rest: [4])
-  let result = non_empty_list.append(left, right)
+  let result = non_empty_list.append(left: left, right: right)
   let assert NonEmptyList(first: 1, rest: [2, 3, 4]) = result
 }
 
 pub fn append_single_to_single_test() {
   let result =
-    non_empty_list.append(non_empty_list.single(1), non_empty_list.single(2))
+    non_empty_list.append(
+      left: non_empty_list.single(1),
+      right: non_empty_list.single(2),
+    )
   let assert [1, 2] = non_empty_list.to_list(result)
 }
 
@@ -46,7 +49,7 @@ pub fn append_preserves_order_test() {
   let left = NonEmptyList(first: "a", rest: ["b"])
   let right = NonEmptyList(first: "c", rest: ["d"])
   let assert ["a", "b", "c", "d"] =
-    non_empty_list.to_list(non_empty_list.append(left, right))
+    non_empty_list.to_list(non_empty_list.append(left: left, right: right))
 }
 
 // --- concat ---

--- a/test/dataprep/parse_test.gleam
+++ b/test/dataprep/parse_test.gleam
@@ -70,8 +70,11 @@ pub fn int_then_validate_test() {
   let result =
     parse.int("25", NotAnInteger)
     |> validated.and_then(
-      rules.min_int(0, TooSmall(0))
-      |> validator.both(rules.max_int(100, TooBig(100))),
+      rules.min_int(minimum: 0, error: TooSmall(0))
+      |> validator.both(
+        first: _,
+        second: rules.max_int(maximum: 100, error: TooBig(100)),
+      ),
     )
   let assert Valid(25) = result
 }
@@ -80,6 +83,7 @@ pub fn int_parse_fail_short_circuits_test() {
   let result =
     parse.int("abc", NotAnInteger)
     |> validated.and_then(fn(_) {
+      // nolint: avoid_panic -- verifies parse failure short-circuits validation
       panic as "should not reach validation after parse failure"
     })
   let assert Invalid(nel) = result
@@ -89,7 +93,7 @@ pub fn int_parse_fail_short_circuits_test() {
 pub fn int_then_validate_out_of_range_test() {
   let result =
     parse.int("200", NotAnInteger)
-    |> validated.and_then(rules.max_int(100, TooBig(100)))
+    |> validated.and_then(rules.max_int(maximum: 100, error: TooBig(100)))
   let assert Invalid(nel) = result
   let assert [TooBig(100)] = non_empty_list.to_list(nel)
 }

--- a/test/dataprep/parse_test.gleam
+++ b/test/dataprep/parse_test.gleam
@@ -4,7 +4,7 @@ import dataprep/rules
 import dataprep/validated.{Invalid, Valid}
 import dataprep/validator
 
-pub type Err {
+type Err {
   NotAnInteger(raw: String)
   NotAFloat(raw: String)
   TooSmall(min: Int)
@@ -13,62 +13,61 @@ pub type Err {
 
 // --- parse.int ---
 
-pub fn int_pass_test() {
-  let assert Valid(42) = parse.int("42", NotAnInteger)
+pub fn int_pass_test() -> Nil {
+  assert parse.int("42", NotAnInteger) == Valid(42)
 }
 
-pub fn int_negative_test() {
-  let assert Valid(-10) = parse.int("-10", NotAnInteger)
+pub fn int_negative_test() -> Nil {
+  assert parse.int("-10", NotAnInteger) == Valid(-10)
 }
 
-pub fn int_zero_test() {
-  let assert Valid(0) = parse.int("0", NotAnInteger)
+pub fn int_zero_test() -> Nil {
+  assert parse.int("0", NotAnInteger) == Valid(0)
 }
 
-pub fn int_fail_test() {
-  let assert Invalid(nel) = parse.int("abc", NotAnInteger)
-  let assert [NotAnInteger("abc")] = non_empty_list.to_list(nel)
+pub fn int_fail_test() -> Nil {
+  assert parse.int("abc", NotAnInteger)
+    == Invalid(non_empty_list.single(NotAnInteger("abc")))
 }
 
-pub fn int_fail_float_string_test() {
-  let assert Invalid(nel) = parse.int("1.5", NotAnInteger)
-  let assert [NotAnInteger("1.5")] = non_empty_list.to_list(nel)
+pub fn int_fail_float_string_test() -> Nil {
+  assert parse.int("1.5", NotAnInteger)
+    == Invalid(non_empty_list.single(NotAnInteger("1.5")))
 }
 
-pub fn int_fail_empty_test() {
-  let assert Invalid(nel) = parse.int("", NotAnInteger)
-  let assert [NotAnInteger("")] = non_empty_list.to_list(nel)
+pub fn int_fail_empty_test() -> Nil {
+  assert parse.int("", NotAnInteger)
+    == Invalid(non_empty_list.single(NotAnInteger("")))
 }
 
 // --- parse.float ---
 
-pub fn float_pass_test() {
-  let assert Valid(3.14) = parse.float("3.14", NotAFloat)
+pub fn float_pass_test() -> Nil {
+  assert parse.float("3.14", NotAFloat) == Valid(3.14)
 }
 
-pub fn float_negative_test() {
-  let assert Valid(-1.5) = parse.float("-1.5", NotAFloat)
+pub fn float_negative_test() -> Nil {
+  assert parse.float("-1.5", NotAFloat) == Valid(-1.5)
 }
 
-pub fn float_zero_test() {
-  let assert Valid(0.0) = parse.float("0.0", NotAFloat)
+pub fn float_zero_test() -> Nil {
+  assert parse.float("0.0", NotAFloat) == Valid(0.0)
 }
 
-pub fn float_fail_test() {
-  let assert Invalid(nel) = parse.float("abc", NotAFloat)
-  let assert [NotAFloat("abc")] = non_empty_list.to_list(nel)
+pub fn float_fail_test() -> Nil {
+  assert parse.float("abc", NotAFloat)
+    == Invalid(non_empty_list.single(NotAFloat("abc")))
 }
 
-pub fn float_fail_empty_test() {
-  let assert Invalid(nel) = parse.float("", NotAFloat)
-  let assert [NotAFloat("")] = non_empty_list.to_list(nel)
+pub fn float_fail_empty_test() -> Nil {
+  assert parse.float("", NotAFloat)
+    == Invalid(non_empty_list.single(NotAFloat("")))
 }
 
 // --- parse + validate pipeline ---
 
-pub fn int_then_validate_test() {
-  let result =
-    parse.int("25", NotAnInteger)
+pub fn int_then_validate_test() -> Nil {
+  assert parse.int("25", NotAnInteger)
     |> validated.and_then(
       rules.min_int(minimum: 0, error: TooSmall(0))
       |> validator.both(
@@ -76,24 +75,20 @@ pub fn int_then_validate_test() {
         second: rules.max_int(maximum: 100, error: TooBig(100)),
       ),
     )
-  let assert Valid(25) = result
+    == Valid(25)
 }
 
-pub fn int_parse_fail_short_circuits_test() {
-  let result =
-    parse.int("abc", NotAnInteger)
+pub fn int_parse_fail_short_circuits_test() -> Nil {
+  assert parse.int("abc", NotAnInteger)
     |> validated.and_then(fn(_) {
       // nolint: avoid_panic -- verifies parse failure short-circuits validation
       panic as "should not reach validation after parse failure"
     })
-  let assert Invalid(nel) = result
-  let assert [NotAnInteger("abc")] = non_empty_list.to_list(nel)
+    == Invalid(non_empty_list.single(NotAnInteger("abc")))
 }
 
-pub fn int_then_validate_out_of_range_test() {
-  let result =
-    parse.int("200", NotAnInteger)
+pub fn int_then_validate_out_of_range_test() -> Nil {
+  assert parse.int("200", NotAnInteger)
     |> validated.and_then(rules.max_int(maximum: 100, error: TooBig(100)))
-  let assert Invalid(nel) = result
-  let assert [TooBig(100)] = non_empty_list.to_list(nel)
+    == Invalid(non_empty_list.single(TooBig(100)))
 }

--- a/test/dataprep/prep_test.gleam
+++ b/test/dataprep/prep_test.gleam
@@ -87,20 +87,20 @@ pub fn collapse_space_tabs_and_newlines_test() {
 // --- replace ---
 
 pub fn replace_test() {
-  let p = prep.replace("-", "_")
+  let p = prep.replace(target: "-", replacement: "_")
   let assert "foo_bar_baz" = p("foo-bar-baz")
 }
 
 pub fn replace_no_match_test() {
-  let assert "hello" = prep.replace("-", "_")("hello")
+  let assert "hello" = prep.replace(target: "-", replacement: "_")("hello")
 }
 
 pub fn replace_absent_target_test() {
-  let assert "hello" = prep.replace("x", "y")("hello")
+  let assert "hello" = prep.replace(target: "x", replacement: "y")("hello")
 }
 
 pub fn replace_to_empty_test() {
-  let assert "hllo" = prep.replace("e", "")("hello")
+  let assert "hllo" = prep.replace(target: "e", replacement: "")("hello")
 }
 
 // --- default ---
@@ -123,25 +123,25 @@ pub fn default_whitespace_only_test() {
 // --- then (composition) ---
 
 pub fn then_test() {
-  let p = prep.trim() |> prep.then(prep.lowercase())
+  let p = prep.trim() |> prep.then(first: _, next: prep.lowercase())
   let assert "hello" = p("  HELLO  ")
 }
 
 pub fn then_order_matters_test() {
   // trim then default("X") -> "  " becomes "" becomes "X"
-  let p1 = prep.trim() |> prep.then(prep.default("X"))
+  let p1 = prep.trim() |> prep.then(first: _, next: prep.default("X"))
   let assert "X" = p1("  ")
 
   // default("X") then trim -> "  " is not "", so default is no-op, then trim -> ""
-  let p2 = prep.default("X") |> prep.then(prep.trim())
+  let p2 = prep.default("X") |> prep.then(first: _, next: prep.trim())
   let assert "" = p2("  ")
 }
 
 pub fn then_three_steps_test() {
   let p =
     prep.trim()
-    |> prep.then(prep.lowercase())
-    |> prep.then(prep.collapse_space())
+    |> prep.then(first: _, next: prep.lowercase())
+    |> prep.then(first: _, next: prep.collapse_space())
   let assert "hello world" = p("  Hello   World  ")
 }
 
@@ -165,7 +165,7 @@ pub fn sequence_single_test() {
 // --- composition patterns ---
 
 pub fn trim_then_default_test() {
-  let p = prep.trim() |> prep.then(prep.default("N/A"))
+  let p = prep.trim() |> prep.then(first: _, next: prep.default("N/A"))
   let assert "N/A" = p("   ")
   let assert "hello" = p("hello")
   let assert "N/A" = p("")
@@ -177,7 +177,7 @@ pub fn full_pipeline_test() {
       prep.trim(),
       prep.lowercase(),
       prep.collapse_space(),
-      prep.replace(".", ""),
+      prep.replace(target: ".", replacement: ""),
     ])
   let assert "john doe jr" = clean("  John.  DOE.  Jr  ")
 }

--- a/test/dataprep/prep_test.gleam
+++ b/test/dataprep/prep_test.gleam
@@ -2,176 +2,179 @@ import dataprep/prep
 
 // --- identity ---
 
-pub fn identity_test() {
-  let p = prep.identity()
-  let assert "hello" = p("hello")
+pub fn identity_test() -> Nil {
+  let prepper = prep.identity()
+  assert prepper("hello") == "hello"
 }
 
-pub fn identity_empty_test() {
-  let p = prep.identity()
-  let assert "" = p("")
+pub fn identity_empty_test() -> Nil {
+  let prepper = prep.identity()
+  assert prepper("") == ""
 }
 
 // --- trim ---
 
-pub fn trim_test() {
-  let p = prep.trim()
-  let assert "hello" = p("  hello  ")
+pub fn trim_test() -> Nil {
+  let prepper = prep.trim()
+  assert prepper("  hello  ") == "hello"
 }
 
-pub fn trim_empty_test() {
-  let assert "" = prep.trim()("")
+pub fn trim_empty_test() -> Nil {
+  assert prep.trim()("") == ""
 }
 
-pub fn trim_only_whitespace_test() {
-  let assert "" = prep.trim()("   \t\n  ")
+pub fn trim_only_whitespace_test() -> Nil {
+  assert prep.trim()("   \t\n  ") == ""
 }
 
-pub fn trim_no_whitespace_test() {
-  let assert "hello" = prep.trim()("hello")
+pub fn trim_no_whitespace_test() -> Nil {
+  assert prep.trim()("hello") == "hello"
 }
 
 // --- lowercase ---
 
-pub fn lowercase_test() {
-  let p = prep.lowercase()
-  let assert "hello" = p("HELLO")
+pub fn lowercase_test() -> Nil {
+  let prepper = prep.lowercase()
+  assert prepper("HELLO") == "hello"
 }
 
-pub fn lowercase_mixed_test() {
-  let assert "hello world" = prep.lowercase()("Hello World")
+pub fn lowercase_mixed_test() -> Nil {
+  assert prep.lowercase()("Hello World") == "hello world"
 }
 
-pub fn lowercase_empty_test() {
-  let assert "" = prep.lowercase()("")
+pub fn lowercase_empty_test() -> Nil {
+  assert prep.lowercase()("") == ""
 }
 
-pub fn lowercase_already_lower_test() {
-  let assert "abc" = prep.lowercase()("abc")
+pub fn lowercase_already_lower_test() -> Nil {
+  assert prep.lowercase()("abc") == "abc"
 }
 
 // --- uppercase ---
 
-pub fn uppercase_test() {
-  let p = prep.uppercase()
-  let assert "HELLO" = p("hello")
+pub fn uppercase_test() -> Nil {
+  let prepper = prep.uppercase()
+  assert prepper("hello") == "HELLO"
 }
 
-pub fn uppercase_empty_test() {
-  let assert "" = prep.uppercase()("")
+pub fn uppercase_empty_test() -> Nil {
+  assert prep.uppercase()("") == ""
 }
 
 // --- collapse_space ---
 
-pub fn collapse_space_test() {
-  let p = prep.collapse_space()
-  let assert "a b c" = p("a   b\t\tc")
+pub fn collapse_space_test() -> Nil {
+  let prepper = prep.collapse_space()
+  assert prepper("a   b\t\tc") == "a b c"
 }
 
-pub fn collapse_space_single_space_test() {
-  let assert "a b" = prep.collapse_space()("a b")
+pub fn collapse_space_single_space_test() -> Nil {
+  assert prep.collapse_space()("a b") == "a b"
 }
 
-pub fn collapse_space_leading_trailing_test() {
-  let assert " hello world " = prep.collapse_space()("  hello   world  ")
+pub fn collapse_space_leading_trailing_test() -> Nil {
+  assert prep.collapse_space()("  hello   world  ") == " hello world "
 }
 
-pub fn collapse_space_empty_test() {
-  let assert "" = prep.collapse_space()("")
+pub fn collapse_space_empty_test() -> Nil {
+  assert prep.collapse_space()("") == ""
 }
 
-pub fn collapse_space_tabs_and_newlines_test() {
-  let assert " a b " = prep.collapse_space()("\t\na\n\n\tb\t")
+pub fn collapse_space_tabs_and_newlines_test() -> Nil {
+  assert prep.collapse_space()("\t\na\n\n\tb\t") == " a b "
 }
 
 // --- replace ---
 
-pub fn replace_test() {
-  let p = prep.replace(target: "-", replacement: "_")
-  let assert "foo_bar_baz" = p("foo-bar-baz")
+pub fn replace_test() -> Nil {
+  let prepper = prep.replace(target: "-", replacement: "_")
+  assert prepper("foo-bar-baz") == "foo_bar_baz"
 }
 
-pub fn replace_no_match_test() {
-  let assert "hello" = prep.replace(target: "-", replacement: "_")("hello")
+pub fn replace_no_match_test() -> Nil {
+  assert prep.replace(target: "-", replacement: "_")("hello") == "hello"
 }
 
-pub fn replace_absent_target_test() {
-  let assert "hello" = prep.replace(target: "x", replacement: "y")("hello")
+pub fn replace_absent_target_test() -> Nil {
+  assert prep.replace(target: "x", replacement: "y")("hello") == "hello"
 }
 
-pub fn replace_to_empty_test() {
-  let assert "hllo" = prep.replace(target: "e", replacement: "")("hello")
+pub fn replace_to_empty_test() -> Nil {
+  assert prep.replace(target: "e", replacement: "")("hello") == "hllo"
 }
 
 // --- default ---
 
-pub fn default_empty_string_test() {
-  let p = prep.default("N/A")
-  let assert "N/A" = p("")
+pub fn default_empty_string_test() -> Nil {
+  let prepper = prep.default("N/A")
+  assert prepper("") == "N/A"
 }
 
-pub fn default_non_empty_test() {
-  let p = prep.default("N/A")
-  let assert "hello" = p("hello")
+pub fn default_non_empty_test() -> Nil {
+  let prepper = prep.default("N/A")
+  assert prepper("hello") == "hello"
 }
 
-pub fn default_whitespace_only_test() {
-  let p = prep.default("N/A")
-  let assert "   " = p("   ")
+pub fn default_whitespace_only_test() -> Nil {
+  let prepper = prep.default("N/A")
+  assert prepper("   ") == "   "
 }
 
 // --- then (composition) ---
 
-pub fn then_test() {
-  let p = prep.trim() |> prep.then(first: _, next: prep.lowercase())
-  let assert "hello" = p("  HELLO  ")
+pub fn then_test() -> Nil {
+  let prepper = prep.trim() |> prep.then(first: _, next: prep.lowercase())
+  assert prepper("  HELLO  ") == "hello"
 }
 
-pub fn then_order_matters_test() {
+pub fn then_order_matters_test() -> Nil {
   // trim then default("X") -> "  " becomes "" becomes "X"
-  let p1 = prep.trim() |> prep.then(first: _, next: prep.default("X"))
-  let assert "X" = p1("  ")
+  let trim_then_default =
+    prep.trim() |> prep.then(first: _, next: prep.default("X"))
+  assert trim_then_default("  ") == "X"
 
   // default("X") then trim -> "  " is not "", so default is no-op, then trim -> ""
-  let p2 = prep.default("X") |> prep.then(first: _, next: prep.trim())
-  let assert "" = p2("  ")
+  let default_then_trim =
+    prep.default("X") |> prep.then(first: _, next: prep.trim())
+  assert default_then_trim("  ") == ""
 }
 
-pub fn then_three_steps_test() {
-  let p =
+pub fn then_three_steps_test() -> Nil {
+  let prepper =
     prep.trim()
     |> prep.then(first: _, next: prep.lowercase())
     |> prep.then(first: _, next: prep.collapse_space())
-  let assert "hello world" = p("  Hello   World  ")
+  assert prepper("  Hello   World  ") == "hello world"
 }
 
 // --- sequence ---
 
-pub fn sequence_test() {
-  let p = prep.sequence([prep.trim(), prep.lowercase(), prep.collapse_space()])
-  let assert "john doe" = p("  John   DOE  ")
+pub fn sequence_test() -> Nil {
+  let prepper =
+    prep.sequence([prep.trim(), prep.lowercase(), prep.collapse_space()])
+  assert prepper("  John   DOE  ") == "john doe"
 }
 
-pub fn sequence_empty_test() {
-  let p = prep.sequence([])
-  let assert "unchanged" = p("unchanged")
+pub fn sequence_empty_test() -> Nil {
+  let prepper = prep.sequence([])
+  assert prepper("unchanged") == "unchanged"
 }
 
-pub fn sequence_single_test() {
-  let p = prep.sequence([prep.trim()])
-  let assert "hello" = p("  hello  ")
+pub fn sequence_single_test() -> Nil {
+  let prepper = prep.sequence([prep.trim()])
+  assert prepper("  hello  ") == "hello"
 }
 
 // --- composition patterns ---
 
-pub fn trim_then_default_test() {
-  let p = prep.trim() |> prep.then(first: _, next: prep.default("N/A"))
-  let assert "N/A" = p("   ")
-  let assert "hello" = p("hello")
-  let assert "N/A" = p("")
+pub fn trim_then_default_test() -> Nil {
+  let prepper = prep.trim() |> prep.then(first: _, next: prep.default("N/A"))
+  assert prepper("   ") == "N/A"
+  assert prepper("hello") == "hello"
+  assert prepper("") == "N/A"
 }
 
-pub fn full_pipeline_test() {
+pub fn full_pipeline_test() -> Nil {
   let clean =
     prep.sequence([
       prep.trim(),
@@ -179,5 +182,5 @@ pub fn full_pipeline_test() {
       prep.collapse_space(),
       prep.replace(target: ".", replacement: ""),
     ])
-  let assert "john doe jr" = clean("  John.  DOE.  Jr  ")
+  assert clean("  John.  DOE.  Jr  ") == "john doe jr"
 }

--- a/test/dataprep/rules_new_test.gleam
+++ b/test/dataprep/rules_new_test.gleam
@@ -4,165 +4,186 @@ import dataprep/validated.{Invalid, Valid}
 import dataprep/validator
 import gleam/regexp
 
-pub type Err {
+type Err {
   IsBlank
   BadFormat
-  TooShort(min: Int)
-  TooLong(max: Int)
   BadLength
   TooSmallFloat
   TooBigFloat
   Negative
 }
 
+fn compile_regexp(pattern: String) -> regexp.Regexp {
+  // nolint: assert_ok_pattern -- test regex literals are fixed and known-valid
+  let assert Ok(compiled) = regexp.from_string(pattern)
+  compiled
+}
+
 // --- not_blank ---
 
-pub fn not_blank_pass_test() {
-  let assert Valid("hello") = rules.not_blank(IsBlank)("hello")
+pub fn not_blank_pass_test() -> Nil {
+  assert rules.not_blank(IsBlank)("hello") == Valid("hello")
 }
 
-pub fn not_blank_fail_empty_test() {
-  let assert Invalid(nel) = rules.not_blank(IsBlank)("")
-  let assert [IsBlank] = non_empty_list.to_list(nel)
+pub fn not_blank_fail_empty_test() -> Nil {
+  assert rules.not_blank(IsBlank)("") == Invalid(non_empty_list.single(IsBlank))
 }
 
-pub fn not_blank_fail_whitespace_test() {
-  let assert Invalid(nel) = rules.not_blank(IsBlank)("   ")
-  let assert [IsBlank] = non_empty_list.to_list(nel)
+pub fn not_blank_fail_whitespace_test() -> Nil {
+  assert rules.not_blank(IsBlank)("   ")
+    == Invalid(non_empty_list.single(IsBlank))
 }
 
-pub fn not_blank_fail_tabs_newlines_test() {
-  let assert Invalid(_) = rules.not_blank(IsBlank)("\t\n  ")
+pub fn not_blank_fail_tabs_newlines_test() -> Nil {
+  assert case rules.not_blank(IsBlank)("\t\n  ") {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
 }
 
-pub fn not_blank_pass_with_content_test() {
-  let assert Valid("  hello  ") = rules.not_blank(IsBlank)("  hello  ")
+pub fn not_blank_pass_with_content_test() -> Nil {
+  assert rules.not_blank(IsBlank)("  hello  ") == Valid("  hello  ")
 }
 
 // --- matches ---
 
-pub fn matches_pass_test() {
-  let assert Ok(re) = regexp.from_string("^[a-z0-9]+$")
-  let assert Valid("abc123") =
-    rules.matches(pattern: re, error: BadFormat)("abc123")
+pub fn matches_pass_test() -> Nil {
+  let pattern = compile_regexp("^[a-z0-9]+$")
+  assert rules.matches(pattern: pattern, error: BadFormat)("abc123")
+    == Valid("abc123")
 }
 
-pub fn matches_fail_test() {
-  let assert Ok(re) = regexp.from_string("^[a-z]+$")
-  let assert Invalid(nel) =
-    rules.matches(pattern: re, error: BadFormat)("abc123")
-  let assert [BadFormat] = non_empty_list.to_list(nel)
+pub fn matches_fail_test() -> Nil {
+  let pattern = compile_regexp("^[a-z]+$")
+  assert rules.matches(pattern: pattern, error: BadFormat)("abc123")
+    == Invalid(non_empty_list.single(BadFormat))
 }
 
-pub fn matches_empty_string_test() {
-  let assert Ok(re) = regexp.from_string("^.+$")
-  let assert Invalid(_) = rules.matches(pattern: re, error: BadFormat)("")
+pub fn matches_empty_string_test() -> Nil {
+  let pattern = compile_regexp("^.+$")
+  assert case rules.matches(pattern: pattern, error: BadFormat)("") {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
 }
 
-pub fn matches_with_guard_test() {
-  let assert Ok(re) = regexp.from_string("^[a-z]+$")
-  let v =
+pub fn matches_with_guard_test() -> Nil {
+  let pattern = compile_regexp("^[a-z]+$")
+  let validator_under_test =
     rules.not_empty(IsBlank)
     |> validator.guard(
       pre: _,
-      main: rules.matches(pattern: re, error: BadFormat),
+      main: rules.matches(pattern: pattern, error: BadFormat),
     )
-  let assert Invalid(nel) = v("")
-  let assert [IsBlank] = non_empty_list.to_list(nel)
-  let assert Invalid(nel2) = v("ABC")
-  let assert [BadFormat] = non_empty_list.to_list(nel2)
-  let assert Valid("abc") = v("abc")
+  assert validator_under_test("") == Invalid(non_empty_list.single(IsBlank))
+  assert validator_under_test("ABC")
+    == Invalid(non_empty_list.single(BadFormat))
+  assert validator_under_test("abc") == Valid("abc")
 }
 
 // --- length_between ---
 
-pub fn length_between_pass_test() {
-  let assert Valid("abc") =
-    rules.length_between(minimum: 2, maximum: 5, error: BadLength)("abc")
+pub fn length_between_pass_test() -> Nil {
+  assert rules.length_between(minimum: 2, maximum: 5, error: BadLength)("abc")
+    == Valid("abc")
 }
 
-pub fn length_between_exact_min_test() {
-  let assert Valid("ab") =
-    rules.length_between(minimum: 2, maximum: 5, error: BadLength)("ab")
+pub fn length_between_exact_min_test() -> Nil {
+  assert rules.length_between(minimum: 2, maximum: 5, error: BadLength)("ab")
+    == Valid("ab")
 }
 
-pub fn length_between_exact_max_test() {
-  let assert Valid("abcde") =
-    rules.length_between(minimum: 2, maximum: 5, error: BadLength)("abcde")
+pub fn length_between_exact_max_test() -> Nil {
+  assert rules.length_between(minimum: 2, maximum: 5, error: BadLength)("abcde")
+    == Valid("abcde")
 }
 
-pub fn length_between_fail_short_test() {
-  let assert Invalid(_) =
+pub fn length_between_fail_short_test() -> Nil {
+  assert case
     rules.length_between(minimum: 2, maximum: 5, error: BadLength)("a")
+  {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
 }
 
-pub fn length_between_fail_long_test() {
-  let assert Invalid(_) =
+pub fn length_between_fail_long_test() -> Nil {
+  assert case
     rules.length_between(minimum: 2, maximum: 5, error: BadLength)("abcdef")
+  {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
 }
 
 // --- min_float / max_float ---
 
-pub fn min_float_pass_test() {
-  let assert Valid(1.5) =
-    rules.min_float(minimum: 1.0, error: TooSmallFloat)(1.5)
+pub fn min_float_pass_test() -> Nil {
+  assert rules.min_float(minimum: 1.0, error: TooSmallFloat)(1.5) == Valid(1.5)
 }
 
-pub fn min_float_boundary_test() {
-  let assert Valid(1.0) =
-    rules.min_float(minimum: 1.0, error: TooSmallFloat)(1.0)
+pub fn min_float_boundary_test() -> Nil {
+  assert rules.min_float(minimum: 1.0, error: TooSmallFloat)(1.0) == Valid(1.0)
 }
 
-pub fn min_float_fail_test() {
-  let assert Invalid(_) =
-    rules.min_float(minimum: 1.0, error: TooSmallFloat)(0.5)
+pub fn min_float_fail_test() -> Nil {
+  assert case rules.min_float(minimum: 1.0, error: TooSmallFloat)(0.5) {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
 }
 
-pub fn max_float_pass_test() {
-  let assert Valid(5.0) =
-    rules.max_float(maximum: 10.0, error: TooBigFloat)(5.0)
+pub fn max_float_pass_test() -> Nil {
+  assert rules.max_float(maximum: 10.0, error: TooBigFloat)(5.0) == Valid(5.0)
 }
 
-pub fn max_float_boundary_test() {
-  let assert Valid(10.0) =
-    rules.max_float(maximum: 10.0, error: TooBigFloat)(10.0)
+pub fn max_float_boundary_test() -> Nil {
+  assert rules.max_float(maximum: 10.0, error: TooBigFloat)(10.0) == Valid(10.0)
 }
 
-pub fn max_float_fail_test() {
-  let assert Invalid(_) =
-    rules.max_float(maximum: 10.0, error: TooBigFloat)(10.1)
+pub fn max_float_fail_test() -> Nil {
+  assert case rules.max_float(maximum: 10.0, error: TooBigFloat)(10.1) {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
 }
 
-pub fn min_max_float_combined_test() {
-  let v =
+pub fn min_max_float_combined_test() -> Nil {
+  let validator_under_test =
     rules.min_float(minimum: 0.0, error: TooSmallFloat)
     |> validator.both(
       first: _,
       second: rules.max_float(maximum: 100.0, error: TooBigFloat),
     )
-  let assert Valid(50.0) = v(50.0)
-  let assert Invalid(_) = v(-0.1)
-  let assert Invalid(_) = v(100.1)
+  assert validator_under_test(50.0) == Valid(50.0)
+  assert case validator_under_test(-0.1) {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
+  assert case validator_under_test(100.1) {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
 }
 
 // --- non_negative_int / non_negative_float ---
 
-pub fn non_negative_int_pass_test() {
-  let assert Valid(0) = rules.non_negative_int(Negative)(0)
-  let assert Valid(42) = rules.non_negative_int(Negative)(42)
+pub fn non_negative_int_pass_test() -> Nil {
+  assert rules.non_negative_int(Negative)(0) == Valid(0)
+  assert rules.non_negative_int(Negative)(42) == Valid(42)
 }
 
-pub fn non_negative_int_fail_test() {
-  let assert Invalid(nel) = rules.non_negative_int(Negative)(-1)
-  let assert [Negative] = non_empty_list.to_list(nel)
+pub fn non_negative_int_fail_test() -> Nil {
+  assert rules.non_negative_int(Negative)(-1)
+    == Invalid(non_empty_list.single(Negative))
 }
 
-pub fn non_negative_float_pass_test() {
-  let assert Valid(0.0) = rules.non_negative_float(Negative)(0.0)
-  let assert Valid(1.5) = rules.non_negative_float(Negative)(1.5)
+pub fn non_negative_float_pass_test() -> Nil {
+  assert rules.non_negative_float(Negative)(0.0) == Valid(0.0)
+  assert rules.non_negative_float(Negative)(1.5) == Valid(1.5)
 }
 
-pub fn non_negative_float_fail_test() {
-  let assert Invalid(nel) = rules.non_negative_float(Negative)(-0.1)
-  let assert [Negative] = non_empty_list.to_list(nel)
+pub fn non_negative_float_fail_test() -> Nil {
+  assert rules.non_negative_float(Negative)(-0.1)
+    == Invalid(non_empty_list.single(Negative))
 }

--- a/test/dataprep/rules_new_test.gleam
+++ b/test/dataprep/rules_new_test.gleam
@@ -43,25 +43,30 @@ pub fn not_blank_pass_with_content_test() {
 
 pub fn matches_pass_test() {
   let assert Ok(re) = regexp.from_string("^[a-z0-9]+$")
-  let assert Valid("abc123") = rules.matches(re, BadFormat)("abc123")
+  let assert Valid("abc123") =
+    rules.matches(pattern: re, error: BadFormat)("abc123")
 }
 
 pub fn matches_fail_test() {
   let assert Ok(re) = regexp.from_string("^[a-z]+$")
-  let assert Invalid(nel) = rules.matches(re, BadFormat)("abc123")
+  let assert Invalid(nel) =
+    rules.matches(pattern: re, error: BadFormat)("abc123")
   let assert [BadFormat] = non_empty_list.to_list(nel)
 }
 
 pub fn matches_empty_string_test() {
   let assert Ok(re) = regexp.from_string("^.+$")
-  let assert Invalid(_) = rules.matches(re, BadFormat)("")
+  let assert Invalid(_) = rules.matches(pattern: re, error: BadFormat)("")
 }
 
 pub fn matches_with_guard_test() {
   let assert Ok(re) = regexp.from_string("^[a-z]+$")
   let v =
     rules.not_empty(IsBlank)
-    |> validator.guard(rules.matches(re, BadFormat))
+    |> validator.guard(
+      pre: _,
+      main: rules.matches(pattern: re, error: BadFormat),
+    )
   let assert Invalid(nel) = v("")
   let assert [IsBlank] = non_empty_list.to_list(nel)
   let assert Invalid(nel2) = v("ABC")
@@ -72,55 +77,69 @@ pub fn matches_with_guard_test() {
 // --- length_between ---
 
 pub fn length_between_pass_test() {
-  let assert Valid("abc") = rules.length_between(2, 5, BadLength)("abc")
+  let assert Valid("abc") =
+    rules.length_between(minimum: 2, maximum: 5, error: BadLength)("abc")
 }
 
 pub fn length_between_exact_min_test() {
-  let assert Valid("ab") = rules.length_between(2, 5, BadLength)("ab")
+  let assert Valid("ab") =
+    rules.length_between(minimum: 2, maximum: 5, error: BadLength)("ab")
 }
 
 pub fn length_between_exact_max_test() {
-  let assert Valid("abcde") = rules.length_between(2, 5, BadLength)("abcde")
+  let assert Valid("abcde") =
+    rules.length_between(minimum: 2, maximum: 5, error: BadLength)("abcde")
 }
 
 pub fn length_between_fail_short_test() {
-  let assert Invalid(_) = rules.length_between(2, 5, BadLength)("a")
+  let assert Invalid(_) =
+    rules.length_between(minimum: 2, maximum: 5, error: BadLength)("a")
 }
 
 pub fn length_between_fail_long_test() {
-  let assert Invalid(_) = rules.length_between(2, 5, BadLength)("abcdef")
+  let assert Invalid(_) =
+    rules.length_between(minimum: 2, maximum: 5, error: BadLength)("abcdef")
 }
 
 // --- min_float / max_float ---
 
 pub fn min_float_pass_test() {
-  let assert Valid(1.5) = rules.min_float(1.0, TooSmallFloat)(1.5)
+  let assert Valid(1.5) =
+    rules.min_float(minimum: 1.0, error: TooSmallFloat)(1.5)
 }
 
 pub fn min_float_boundary_test() {
-  let assert Valid(1.0) = rules.min_float(1.0, TooSmallFloat)(1.0)
+  let assert Valid(1.0) =
+    rules.min_float(minimum: 1.0, error: TooSmallFloat)(1.0)
 }
 
 pub fn min_float_fail_test() {
-  let assert Invalid(_) = rules.min_float(1.0, TooSmallFloat)(0.5)
+  let assert Invalid(_) =
+    rules.min_float(minimum: 1.0, error: TooSmallFloat)(0.5)
 }
 
 pub fn max_float_pass_test() {
-  let assert Valid(5.0) = rules.max_float(10.0, TooBigFloat)(5.0)
+  let assert Valid(5.0) =
+    rules.max_float(maximum: 10.0, error: TooBigFloat)(5.0)
 }
 
 pub fn max_float_boundary_test() {
-  let assert Valid(10.0) = rules.max_float(10.0, TooBigFloat)(10.0)
+  let assert Valid(10.0) =
+    rules.max_float(maximum: 10.0, error: TooBigFloat)(10.0)
 }
 
 pub fn max_float_fail_test() {
-  let assert Invalid(_) = rules.max_float(10.0, TooBigFloat)(10.1)
+  let assert Invalid(_) =
+    rules.max_float(maximum: 10.0, error: TooBigFloat)(10.1)
 }
 
 pub fn min_max_float_combined_test() {
   let v =
-    rules.min_float(0.0, TooSmallFloat)
-    |> validator.both(rules.max_float(100.0, TooBigFloat))
+    rules.min_float(minimum: 0.0, error: TooSmallFloat)
+    |> validator.both(
+      first: _,
+      second: rules.max_float(maximum: 100.0, error: TooBigFloat),
+    )
   let assert Valid(50.0) = v(50.0)
   let assert Invalid(_) = v(-0.1)
   let assert Invalid(_) = v(100.1)

--- a/test/dataprep/rules_test.gleam
+++ b/test/dataprep/rules_test.gleam
@@ -4,7 +4,7 @@ import dataprep/rules
 import dataprep/validated.{Invalid, Valid}
 import dataprep/validator
 
-pub type Err {
+type Err {
   IsEmpty
   TooShort(min: Int)
   TooLong(max: Int)
@@ -16,197 +16,211 @@ pub type Err {
 
 // --- not_empty ---
 
-pub fn not_empty_pass_test() {
-  let assert Valid("hello") = rules.not_empty(IsEmpty)("hello")
+pub fn not_empty_pass_test() -> Nil {
+  assert rules.not_empty(IsEmpty)("hello") == Valid("hello")
 }
 
-pub fn not_empty_fail_test() {
-  let assert Invalid(nel) = rules.not_empty(IsEmpty)("")
-  let assert [IsEmpty] = non_empty_list.to_list(nel)
+pub fn not_empty_fail_test() -> Nil {
+  assert rules.not_empty(IsEmpty)("") == Invalid(non_empty_list.single(IsEmpty))
 }
 
-pub fn not_empty_whitespace_passes_test() {
-  let assert Valid("   ") = rules.not_empty(IsEmpty)("   ")
+pub fn not_empty_whitespace_passes_test() -> Nil {
+  assert rules.not_empty(IsEmpty)("   ") == Valid("   ")
 }
 
-pub fn not_empty_with_trim_rejects_whitespace_test() {
+pub fn not_empty_with_trim_rejects_whitespace_test() -> Nil {
   let clean = prep.trim()
-  let assert Invalid(nel) = rules.not_empty(IsEmpty)(clean("   "))
-  let assert [IsEmpty] = non_empty_list.to_list(nel)
+  assert rules.not_empty(IsEmpty)(clean("   "))
+    == Invalid(non_empty_list.single(IsEmpty))
 }
 
-pub fn not_empty_single_char_test() {
-  let assert Valid(" ") = rules.not_empty(IsEmpty)(" ")
+pub fn not_empty_single_char_test() -> Nil {
+  assert rules.not_empty(IsEmpty)(" ") == Valid(" ")
 }
 
 // --- min_length ---
 
-pub fn min_length_pass_test() {
-  let assert Valid("abc") =
-    rules.min_length(minimum: 3, error: TooShort(3))("abc")
+pub fn min_length_pass_test() -> Nil {
+  assert rules.min_length(minimum: 3, error: TooShort(3))("abc") == Valid("abc")
 }
 
-pub fn min_length_fail_test() {
-  let assert Invalid(nel) =
-    rules.min_length(minimum: 3, error: TooShort(3))("ab")
-  let assert [TooShort(3)] = non_empty_list.to_list(nel)
+pub fn min_length_fail_test() -> Nil {
+  assert rules.min_length(minimum: 3, error: TooShort(3))("ab")
+    == Invalid(non_empty_list.single(TooShort(3)))
 }
 
-pub fn min_length_exact_boundary_test() {
-  let assert Valid("abc") =
-    rules.min_length(minimum: 3, error: TooShort(3))("abc")
-  let assert Invalid(_) = rules.min_length(minimum: 3, error: TooShort(3))("ab")
+pub fn min_length_exact_boundary_test() -> Nil {
+  assert rules.min_length(minimum: 3, error: TooShort(3))("abc") == Valid("abc")
+  assert case rules.min_length(minimum: 3, error: TooShort(3))("ab") {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
 }
 
-pub fn min_length_zero_test() {
-  let assert Valid("") = rules.min_length(minimum: 0, error: TooShort(0))("")
+pub fn min_length_zero_test() -> Nil {
+  assert rules.min_length(minimum: 0, error: TooShort(0))("") == Valid("")
 }
 
-pub fn min_length_empty_string_test() {
-  let assert Invalid(_) = rules.min_length(minimum: 1, error: TooShort(1))("")
+pub fn min_length_empty_string_test() -> Nil {
+  assert case rules.min_length(minimum: 1, error: TooShort(1))("") {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
 }
 
 // --- max_length ---
 
-pub fn max_length_pass_test() {
-  let assert Valid("abc") =
-    rules.max_length(maximum: 5, error: TooLong(5))("abc")
+pub fn max_length_pass_test() -> Nil {
+  assert rules.max_length(maximum: 5, error: TooLong(5))("abc") == Valid("abc")
 }
 
-pub fn max_length_fail_test() {
-  let assert Invalid(nel) =
-    rules.max_length(maximum: 2, error: TooLong(2))("abc")
-  let assert [TooLong(2)] = non_empty_list.to_list(nel)
+pub fn max_length_fail_test() -> Nil {
+  assert rules.max_length(maximum: 2, error: TooLong(2))("abc")
+    == Invalid(non_empty_list.single(TooLong(2)))
 }
 
-pub fn max_length_exact_boundary_test() {
-  let assert Valid("abc") =
-    rules.max_length(maximum: 3, error: TooLong(3))("abc")
-  let assert Invalid(_) =
-    rules.max_length(maximum: 3, error: TooLong(3))("abcd")
+pub fn max_length_exact_boundary_test() -> Nil {
+  assert rules.max_length(maximum: 3, error: TooLong(3))("abc") == Valid("abc")
+  assert case rules.max_length(maximum: 3, error: TooLong(3))("abcd") {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
 }
 
-pub fn max_length_empty_string_test() {
-  let assert Valid("") = rules.max_length(maximum: 0, error: TooLong(0))("")
+pub fn max_length_empty_string_test() -> Nil {
+  assert rules.max_length(maximum: 0, error: TooLong(0))("") == Valid("")
 }
 
 // --- min_int ---
 
-pub fn min_int_pass_test() {
-  let assert Valid(10) = rules.min_int(minimum: 0, error: TooSmall(0))(10)
+pub fn min_int_pass_test() -> Nil {
+  assert rules.min_int(minimum: 0, error: TooSmall(0))(10) == Valid(10)
 }
 
-pub fn min_int_fail_test() {
-  let assert Invalid(nel) = rules.min_int(minimum: 0, error: TooSmall(0))(-1)
-  let assert [TooSmall(0)] = non_empty_list.to_list(nel)
+pub fn min_int_fail_test() -> Nil {
+  assert rules.min_int(minimum: 0, error: TooSmall(0))(-1)
+    == Invalid(non_empty_list.single(TooSmall(0)))
 }
 
-pub fn min_int_exact_boundary_test() {
-  let assert Valid(0) = rules.min_int(minimum: 0, error: TooSmall(0))(0)
-  let assert Invalid(_) = rules.min_int(minimum: 0, error: TooSmall(0))(-1)
+pub fn min_int_exact_boundary_test() -> Nil {
+  assert rules.min_int(minimum: 0, error: TooSmall(0))(0) == Valid(0)
+  assert case rules.min_int(minimum: 0, error: TooSmall(0))(-1) {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
 }
 
-pub fn min_int_negative_boundary_test() {
-  let assert Valid(-10) = rules.min_int(minimum: -10, error: TooSmall(-10))(-10)
-  let assert Invalid(_) = rules.min_int(minimum: -10, error: TooSmall(-10))(-11)
+pub fn min_int_negative_boundary_test() -> Nil {
+  assert rules.min_int(minimum: -10, error: TooSmall(-10))(-10) == Valid(-10)
+  assert case rules.min_int(minimum: -10, error: TooSmall(-10))(-11) {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
 }
 
 // --- max_int ---
 
-pub fn max_int_pass_test() {
-  let assert Valid(5) = rules.max_int(maximum: 10, error: TooBig(10))(5)
+pub fn max_int_pass_test() -> Nil {
+  assert rules.max_int(maximum: 10, error: TooBig(10))(5) == Valid(5)
 }
 
-pub fn max_int_fail_test() {
-  let assert Invalid(nel) = rules.max_int(maximum: 10, error: TooBig(10))(11)
-  let assert [TooBig(10)] = non_empty_list.to_list(nel)
+pub fn max_int_fail_test() -> Nil {
+  assert rules.max_int(maximum: 10, error: TooBig(10))(11)
+    == Invalid(non_empty_list.single(TooBig(10)))
 }
 
-pub fn max_int_exact_boundary_test() {
-  let assert Valid(10) = rules.max_int(maximum: 10, error: TooBig(10))(10)
-  let assert Invalid(_) = rules.max_int(maximum: 10, error: TooBig(10))(11)
+pub fn max_int_exact_boundary_test() -> Nil {
+  assert rules.max_int(maximum: 10, error: TooBig(10))(10) == Valid(10)
+  assert case rules.max_int(maximum: 10, error: TooBig(10))(11) {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
 }
 
 // --- one_of ---
 
-pub fn one_of_pass_test() {
-  let assert Valid("a") =
-    rules.one_of(allowed: ["a", "b", "c"], error: NotAllowed)("a")
+pub fn one_of_pass_test() -> Nil {
+  assert rules.one_of(allowed: ["a", "b", "c"], error: NotAllowed)("a")
+    == Valid("a")
 }
 
-pub fn one_of_fail_test() {
-  let assert Invalid(nel) =
-    rules.one_of(allowed: ["a", "b", "c"], error: NotAllowed)("d")
-  let assert [NotAllowed] = non_empty_list.to_list(nel)
+pub fn one_of_fail_test() -> Nil {
+  assert rules.one_of(allowed: ["a", "b", "c"], error: NotAllowed)("d")
+    == Invalid(non_empty_list.single(NotAllowed))
 }
 
-pub fn one_of_empty_list_always_fails_test() {
-  let assert Invalid(_) =
-    rules.one_of(allowed: [], error: NotAllowed)("anything")
+pub fn one_of_empty_list_always_fails_test() -> Nil {
+  assert case rules.one_of(allowed: [], error: NotAllowed)("anything") {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
 }
 
-pub fn one_of_int_test() {
-  let assert Valid(1) = rules.one_of(allowed: [1, 2, 3], error: NotAllowed)(1)
-  let assert Invalid(_) = rules.one_of(allowed: [1, 2, 3], error: NotAllowed)(4)
+pub fn one_of_int_test() -> Nil {
+  assert rules.one_of(allowed: [1, 2, 3], error: NotAllowed)(1) == Valid(1)
+  assert case rules.one_of(allowed: [1, 2, 3], error: NotAllowed)(4) {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
 }
 
 // --- equals ---
 
-pub fn equals_pass_test() {
-  let assert Valid(42) = rules.equals(expected: 42, error: NotEqual)(42)
+pub fn equals_pass_test() -> Nil {
+  assert rules.equals(expected: 42, error: NotEqual)(42) == Valid(42)
 }
 
-pub fn equals_fail_test() {
-  let assert Invalid(nel) = rules.equals(expected: 42, error: NotEqual)(99)
-  let assert [NotEqual] = non_empty_list.to_list(nel)
+pub fn equals_fail_test() -> Nil {
+  assert rules.equals(expected: 42, error: NotEqual)(99)
+    == Invalid(non_empty_list.single(NotEqual))
 }
 
-pub fn equals_string_test() {
-  let assert Valid("yes") =
-    rules.equals(expected: "yes", error: NotEqual)("yes")
-  let assert Invalid(_) = rules.equals(expected: "yes", error: NotEqual)("no")
+pub fn equals_string_test() -> Nil {
+  assert rules.equals(expected: "yes", error: NotEqual)("yes") == Valid("yes")
+  assert case rules.equals(expected: "yes", error: NotEqual)("no") {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
 }
 
 // --- rules combined with validator combinators ---
 
-pub fn min_max_length_combined_test() {
-  let v =
+pub fn min_max_length_combined_test() -> Nil {
+  let validator_under_test =
     rules.min_length(minimum: 3, error: TooShort(3))
     |> validator.both(
       first: _,
       second: rules.max_length(maximum: 10, error: TooLong(10)),
     )
-  let assert Valid("hello") = v("hello")
-  let assert Invalid(nel) = v("ab")
-  let assert [TooShort(3)] = non_empty_list.to_list(nel)
-  let assert Invalid(nel2) = v("abcdefghijk")
-  let assert [TooLong(10)] = non_empty_list.to_list(nel2)
+  assert validator_under_test("hello") == Valid("hello")
+  assert validator_under_test("ab")
+    == Invalid(non_empty_list.single(TooShort(3)))
+  assert validator_under_test("abcdefghijk")
+    == Invalid(non_empty_list.single(TooLong(10)))
 }
 
-pub fn min_max_int_combined_test() {
-  let v =
+pub fn min_max_int_combined_test() -> Nil {
+  let validator_under_test =
     rules.min_int(minimum: 0, error: TooSmall(0))
     |> validator.both(
       first: _,
       second: rules.max_int(maximum: 100, error: TooBig(100)),
     )
-  let assert Valid(50) = v(50)
-  let assert Invalid(nel) = v(-1)
-  let assert [TooSmall(0)] = non_empty_list.to_list(nel)
-  let assert Invalid(nel2) = v(101)
-  let assert [TooBig(100)] = non_empty_list.to_list(nel2)
+  assert validator_under_test(50) == Valid(50)
+  assert validator_under_test(-1) == Invalid(non_empty_list.single(TooSmall(0)))
+  assert validator_under_test(101)
+    == Invalid(non_empty_list.single(TooBig(100)))
 }
 
-pub fn not_empty_guard_min_length_test() {
-  let v =
+pub fn not_empty_guard_min_length_test() -> Nil {
+  let validator_under_test =
     rules.not_empty(IsEmpty)
     |> validator.guard(
       pre: _,
       main: rules.min_length(minimum: 3, error: TooShort(3)),
     )
-  let assert Invalid(nel) = v("")
-  let assert [IsEmpty] = non_empty_list.to_list(nel)
-  let assert Invalid(nel2) = v("ab")
-  let assert [TooShort(3)] = non_empty_list.to_list(nel2)
-  let assert Valid("abc") = v("abc")
+  assert validator_under_test("") == Invalid(non_empty_list.single(IsEmpty))
+  assert validator_under_test("ab")
+    == Invalid(non_empty_list.single(TooShort(3)))
+  assert validator_under_test("abc") == Valid("abc")
 }

--- a/test/dataprep/rules_test.gleam
+++ b/test/dataprep/rules_test.gleam
@@ -42,126 +42,140 @@ pub fn not_empty_single_char_test() {
 // --- min_length ---
 
 pub fn min_length_pass_test() {
-  let assert Valid("abc") = rules.min_length(3, TooShort(3))("abc")
+  let assert Valid("abc") =
+    rules.min_length(minimum: 3, error: TooShort(3))("abc")
 }
 
 pub fn min_length_fail_test() {
-  let assert Invalid(nel) = rules.min_length(3, TooShort(3))("ab")
+  let assert Invalid(nel) =
+    rules.min_length(minimum: 3, error: TooShort(3))("ab")
   let assert [TooShort(3)] = non_empty_list.to_list(nel)
 }
 
 pub fn min_length_exact_boundary_test() {
-  let assert Valid("abc") = rules.min_length(3, TooShort(3))("abc")
-  let assert Invalid(_) = rules.min_length(3, TooShort(3))("ab")
+  let assert Valid("abc") =
+    rules.min_length(minimum: 3, error: TooShort(3))("abc")
+  let assert Invalid(_) = rules.min_length(minimum: 3, error: TooShort(3))("ab")
 }
 
 pub fn min_length_zero_test() {
-  let assert Valid("") = rules.min_length(0, TooShort(0))("")
+  let assert Valid("") = rules.min_length(minimum: 0, error: TooShort(0))("")
 }
 
 pub fn min_length_empty_string_test() {
-  let assert Invalid(_) = rules.min_length(1, TooShort(1))("")
+  let assert Invalid(_) = rules.min_length(minimum: 1, error: TooShort(1))("")
 }
 
 // --- max_length ---
 
 pub fn max_length_pass_test() {
-  let assert Valid("abc") = rules.max_length(5, TooLong(5))("abc")
+  let assert Valid("abc") =
+    rules.max_length(maximum: 5, error: TooLong(5))("abc")
 }
 
 pub fn max_length_fail_test() {
-  let assert Invalid(nel) = rules.max_length(2, TooLong(2))("abc")
+  let assert Invalid(nel) =
+    rules.max_length(maximum: 2, error: TooLong(2))("abc")
   let assert [TooLong(2)] = non_empty_list.to_list(nel)
 }
 
 pub fn max_length_exact_boundary_test() {
-  let assert Valid("abc") = rules.max_length(3, TooLong(3))("abc")
-  let assert Invalid(_) = rules.max_length(3, TooLong(3))("abcd")
+  let assert Valid("abc") =
+    rules.max_length(maximum: 3, error: TooLong(3))("abc")
+  let assert Invalid(_) =
+    rules.max_length(maximum: 3, error: TooLong(3))("abcd")
 }
 
 pub fn max_length_empty_string_test() {
-  let assert Valid("") = rules.max_length(0, TooLong(0))("")
+  let assert Valid("") = rules.max_length(maximum: 0, error: TooLong(0))("")
 }
 
 // --- min_int ---
 
 pub fn min_int_pass_test() {
-  let assert Valid(10) = rules.min_int(0, TooSmall(0))(10)
+  let assert Valid(10) = rules.min_int(minimum: 0, error: TooSmall(0))(10)
 }
 
 pub fn min_int_fail_test() {
-  let assert Invalid(nel) = rules.min_int(0, TooSmall(0))(-1)
+  let assert Invalid(nel) = rules.min_int(minimum: 0, error: TooSmall(0))(-1)
   let assert [TooSmall(0)] = non_empty_list.to_list(nel)
 }
 
 pub fn min_int_exact_boundary_test() {
-  let assert Valid(0) = rules.min_int(0, TooSmall(0))(0)
-  let assert Invalid(_) = rules.min_int(0, TooSmall(0))(-1)
+  let assert Valid(0) = rules.min_int(minimum: 0, error: TooSmall(0))(0)
+  let assert Invalid(_) = rules.min_int(minimum: 0, error: TooSmall(0))(-1)
 }
 
 pub fn min_int_negative_boundary_test() {
-  let assert Valid(-10) = rules.min_int(-10, TooSmall(-10))(-10)
-  let assert Invalid(_) = rules.min_int(-10, TooSmall(-10))(-11)
+  let assert Valid(-10) = rules.min_int(minimum: -10, error: TooSmall(-10))(-10)
+  let assert Invalid(_) = rules.min_int(minimum: -10, error: TooSmall(-10))(-11)
 }
 
 // --- max_int ---
 
 pub fn max_int_pass_test() {
-  let assert Valid(5) = rules.max_int(10, TooBig(10))(5)
+  let assert Valid(5) = rules.max_int(maximum: 10, error: TooBig(10))(5)
 }
 
 pub fn max_int_fail_test() {
-  let assert Invalid(nel) = rules.max_int(10, TooBig(10))(11)
+  let assert Invalid(nel) = rules.max_int(maximum: 10, error: TooBig(10))(11)
   let assert [TooBig(10)] = non_empty_list.to_list(nel)
 }
 
 pub fn max_int_exact_boundary_test() {
-  let assert Valid(10) = rules.max_int(10, TooBig(10))(10)
-  let assert Invalid(_) = rules.max_int(10, TooBig(10))(11)
+  let assert Valid(10) = rules.max_int(maximum: 10, error: TooBig(10))(10)
+  let assert Invalid(_) = rules.max_int(maximum: 10, error: TooBig(10))(11)
 }
 
 // --- one_of ---
 
 pub fn one_of_pass_test() {
-  let assert Valid("a") = rules.one_of(["a", "b", "c"], NotAllowed)("a")
+  let assert Valid("a") =
+    rules.one_of(allowed: ["a", "b", "c"], error: NotAllowed)("a")
 }
 
 pub fn one_of_fail_test() {
-  let assert Invalid(nel) = rules.one_of(["a", "b", "c"], NotAllowed)("d")
+  let assert Invalid(nel) =
+    rules.one_of(allowed: ["a", "b", "c"], error: NotAllowed)("d")
   let assert [NotAllowed] = non_empty_list.to_list(nel)
 }
 
 pub fn one_of_empty_list_always_fails_test() {
-  let assert Invalid(_) = rules.one_of([], NotAllowed)("anything")
+  let assert Invalid(_) =
+    rules.one_of(allowed: [], error: NotAllowed)("anything")
 }
 
 pub fn one_of_int_test() {
-  let assert Valid(1) = rules.one_of([1, 2, 3], NotAllowed)(1)
-  let assert Invalid(_) = rules.one_of([1, 2, 3], NotAllowed)(4)
+  let assert Valid(1) = rules.one_of(allowed: [1, 2, 3], error: NotAllowed)(1)
+  let assert Invalid(_) = rules.one_of(allowed: [1, 2, 3], error: NotAllowed)(4)
 }
 
 // --- equals ---
 
 pub fn equals_pass_test() {
-  let assert Valid(42) = rules.equals(42, NotEqual)(42)
+  let assert Valid(42) = rules.equals(expected: 42, error: NotEqual)(42)
 }
 
 pub fn equals_fail_test() {
-  let assert Invalid(nel) = rules.equals(42, NotEqual)(99)
+  let assert Invalid(nel) = rules.equals(expected: 42, error: NotEqual)(99)
   let assert [NotEqual] = non_empty_list.to_list(nel)
 }
 
 pub fn equals_string_test() {
-  let assert Valid("yes") = rules.equals("yes", NotEqual)("yes")
-  let assert Invalid(_) = rules.equals("yes", NotEqual)("no")
+  let assert Valid("yes") =
+    rules.equals(expected: "yes", error: NotEqual)("yes")
+  let assert Invalid(_) = rules.equals(expected: "yes", error: NotEqual)("no")
 }
 
 // --- rules combined with validator combinators ---
 
 pub fn min_max_length_combined_test() {
   let v =
-    rules.min_length(3, TooShort(3))
-    |> validator.both(rules.max_length(10, TooLong(10)))
+    rules.min_length(minimum: 3, error: TooShort(3))
+    |> validator.both(
+      first: _,
+      second: rules.max_length(maximum: 10, error: TooLong(10)),
+    )
   let assert Valid("hello") = v("hello")
   let assert Invalid(nel) = v("ab")
   let assert [TooShort(3)] = non_empty_list.to_list(nel)
@@ -171,8 +185,11 @@ pub fn min_max_length_combined_test() {
 
 pub fn min_max_int_combined_test() {
   let v =
-    rules.min_int(0, TooSmall(0))
-    |> validator.both(rules.max_int(100, TooBig(100)))
+    rules.min_int(minimum: 0, error: TooSmall(0))
+    |> validator.both(
+      first: _,
+      second: rules.max_int(maximum: 100, error: TooBig(100)),
+    )
   let assert Valid(50) = v(50)
   let assert Invalid(nel) = v(-1)
   let assert [TooSmall(0)] = non_empty_list.to_list(nel)
@@ -183,7 +200,10 @@ pub fn min_max_int_combined_test() {
 pub fn not_empty_guard_min_length_test() {
   let v =
     rules.not_empty(IsEmpty)
-    |> validator.guard(rules.min_length(3, TooShort(3)))
+    |> validator.guard(
+      pre: _,
+      main: rules.min_length(minimum: 3, error: TooShort(3)),
+    )
   let assert Invalid(nel) = v("")
   let assert [IsEmpty] = non_empty_list.to_list(nel)
   let assert Invalid(nel2) = v("ab")

--- a/test/dataprep/validated_collection_test.gleam
+++ b/test/dataprep/validated_collection_test.gleam
@@ -3,76 +3,66 @@ import dataprep/rules
 import dataprep/validated.{Invalid, Valid}
 import dataprep/validator
 
-pub type Err {
+type Err {
   TooShort
   Indexed(index: Int, detail: Err)
 }
 
 // --- sequence ---
 
-pub fn sequence_all_valid_test() {
-  let result = validated.sequence([Valid(1), Valid(2), Valid(3)])
-  let assert Valid([1, 2, 3]) = result
+pub fn sequence_all_valid_test() -> Nil {
+  assert validated.sequence([Valid(1), Valid(2), Valid(3)]) == Valid([1, 2, 3])
 }
 
-pub fn sequence_empty_list_test() {
-  let result = validated.sequence([])
-  let assert Valid([]) = result
+pub fn sequence_empty_list_test() -> Nil {
+  assert validated.sequence([]) == Valid([])
 }
 
-pub fn sequence_accumulates_errors_test() {
-  let result =
-    validated.sequence([
+pub fn sequence_accumulates_errors_test() -> Nil {
+  assert validated.sequence([
       Valid(1),
       Invalid(non_empty_list.single("e1")),
       Valid(3),
       Invalid(non_empty_list.single("e2")),
     ])
-  let assert Invalid(nel) = result
-  let assert ["e1", "e2"] = non_empty_list.to_list(nel)
+    == Invalid(non_empty_list.NonEmptyList(first: "e1", rest: ["e2"]))
 }
 
-pub fn sequence_single_invalid_test() {
-  let result = validated.sequence([Invalid(non_empty_list.single("err"))])
-  let assert Invalid(nel) = result
-  let assert ["err"] = non_empty_list.to_list(nel)
+pub fn sequence_single_invalid_test() -> Nil {
+  assert validated.sequence([Invalid(non_empty_list.single("err"))])
+    == Invalid(non_empty_list.single("err"))
 }
 
-pub fn sequence_preserves_order_test() {
-  let result = validated.sequence([Valid("a"), Valid("b"), Valid("c")])
-  let assert Valid(["a", "b", "c"]) = result
+pub fn sequence_preserves_order_test() -> Nil {
+  assert validated.sequence([Valid("a"), Valid("b"), Valid("c")])
+    == Valid(["a", "b", "c"])
 }
 
 // --- traverse ---
 
-pub fn traverse_all_pass_test() {
-  let result =
-    validated.traverse([1, 2, 3], fn(n) {
+pub fn traverse_all_pass_test() -> Nil {
+  assert validated.traverse([1, 2, 3], fn(n) {
       case n > 0 {
         True -> Valid(n)
         False -> Invalid(non_empty_list.single("negative"))
       }
     })
-  let assert Valid([1, 2, 3]) = result
+    == Valid([1, 2, 3])
 }
 
-pub fn traverse_empty_list_test() {
-  let result = validated.traverse([], fn(_) { Valid(1) })
-  let assert Valid([]) = result
+pub fn traverse_empty_list_test() -> Nil {
+  assert validated.traverse([], fn(_) { Valid(1) }) == Valid([])
 }
 
-pub fn traverse_accumulates_errors_test() {
-  let result =
-    validated.traverse(["hello", "", "world", ""], fn(s) {
+pub fn traverse_accumulates_errors_test() -> Nil {
+  assert validated.traverse(["hello", "", "world", ""], fn(s) {
       rules.not_empty(TooShort)(s)
     })
-  let assert Invalid(nel) = result
-  let assert [TooShort, TooShort] = non_empty_list.to_list(nel)
+    == Invalid(non_empty_list.NonEmptyList(first: TooShort, rest: [TooShort]))
 }
 
-pub fn traverse_with_transform_test() {
-  let result =
-    validated.traverse(["1", "2", "3"], fn(s) {
+pub fn traverse_with_transform_test() -> Nil {
+  assert validated.traverse(["1", "2", "3"], fn(s) {
       case s {
         "1" -> Valid(1)
         "2" -> Valid(2)
@@ -80,79 +70,73 @@ pub fn traverse_with_transform_test() {
         _ -> Invalid(non_empty_list.single("bad"))
       }
     })
-  let assert Valid([1, 2, 3]) = result
+    == Valid([1, 2, 3])
 }
 
 // --- traverse_indexed ---
 
-pub fn traverse_indexed_with_label_test() {
-  let result =
-    validated.traverse_indexed(["hello", "", "world"], fn(s, i) {
+pub fn traverse_indexed_with_label_test() -> Nil {
+  assert validated.traverse_indexed(["hello", "", "world"], fn(s, i) {
       rules.not_empty(TooShort)(s)
       |> validated.map_error(fn(e) { Indexed(i, e) })
     })
-  let assert Invalid(nel) = result
-  let assert [Indexed(1, TooShort)] = non_empty_list.to_list(nel)
+    == Invalid(non_empty_list.single(Indexed(1, TooShort)))
 }
 
-pub fn traverse_indexed_all_valid_test() {
-  let result =
-    validated.traverse_indexed(["a", "b", "c"], fn(s, _i) { Valid(s) })
-  let assert Valid(["a", "b", "c"]) = result
+pub fn traverse_indexed_all_valid_test() -> Nil {
+  assert validated.traverse_indexed(["a", "b", "c"], fn(s, _i) { Valid(s) })
+    == Valid(["a", "b", "c"])
 }
 
-pub fn traverse_indexed_empty_test() {
-  let result = validated.traverse_indexed([], fn(_s: String, _i) { Valid("x") })
-  let assert Valid([]) = result
+pub fn traverse_indexed_empty_test() -> Nil {
+  assert validated.traverse_indexed([], fn(_s: String, _i) { Valid("x") })
+    == Valid([])
 }
 
 // --- from_result_map ---
 
-pub fn from_result_map_ok_test() {
-  let result = validated.from_result_map(Ok(42), fn(_) { "err" })
-  let assert Valid(42) = result
+pub fn from_result_map_ok_test() -> Nil {
+  assert validated.from_result_map(Ok(42), fn(_) { "err" }) == Valid(42)
 }
 
-pub fn from_result_map_error_test() {
-  let result = validated.from_result_map(Error(Nil), fn(_) { "mapped" })
-  let assert Invalid(nel) = result
-  let assert ["mapped"] = non_empty_list.to_list(nel)
+pub fn from_result_map_error_test() -> Nil {
+  assert validated.from_result_map(Error(Nil), fn(_) { "mapped" })
+    == Invalid(non_empty_list.single("mapped"))
 }
 
 // --- each ---
 
-pub fn each_all_pass_test() {
+pub fn each_all_pass_test() -> Nil {
   let check = validator.each(rules.not_empty(TooShort))
-  let assert Valid(["a", "b", "c"]) = check(["a", "b", "c"])
+  assert check(["a", "b", "c"]) == Valid(["a", "b", "c"])
 }
 
-pub fn each_accumulates_test() {
+pub fn each_accumulates_test() -> Nil {
   let check = validator.each(rules.not_empty(TooShort))
-  let assert Invalid(nel) = check(["a", "", "b", ""])
-  let assert [TooShort, TooShort] = non_empty_list.to_list(nel)
+  assert check(["a", "", "b", ""])
+    == Invalid(non_empty_list.NonEmptyList(first: TooShort, rest: [TooShort]))
 }
 
-pub fn each_empty_list_test() {
+pub fn each_empty_list_test() -> Nil {
   let check = validator.each(rules.not_empty(TooShort))
-  let assert Valid([]) = check([])
+  assert check([]) == Valid([])
 }
 
 // --- optional ---
 
-pub fn optional_none_test() {
+pub fn optional_none_test() -> Nil {
   let check = validator.optional(rules.not_empty(TooShort))
-  let assert Valid(option.None) = check(option.None)
+  assert check(option.None) == Valid(option.None)
 }
 
-pub fn optional_some_valid_test() {
+pub fn optional_some_valid_test() -> Nil {
   let check = validator.optional(rules.not_empty(TooShort))
-  let assert Valid(option.Some("hello")) = check(option.Some("hello"))
+  assert check(option.Some("hello")) == Valid(option.Some("hello"))
 }
 
-pub fn optional_some_invalid_test() {
+pub fn optional_some_invalid_test() -> Nil {
   let check = validator.optional(rules.not_empty(TooShort))
-  let assert Invalid(nel) = check(option.Some(""))
-  let assert [TooShort] = non_empty_list.to_list(nel)
+  assert check(option.Some("")) == Invalid(non_empty_list.single(TooShort))
 }
 
 import gleam/option

--- a/test/dataprep/validated_test.gleam
+++ b/test/dataprep/validated_test.gleam
@@ -73,6 +73,7 @@ pub fn and_then_short_circuits_test() {
   let result =
     Invalid(non_empty_list.single("first"))
     |> validated.and_then(fn(_) {
+      // nolint: avoid_panic -- verifies and_then short-circuits on Invalid
       panic as "and_then must not call continuation on Invalid"
     })
   let assert Invalid(NonEmptyList(first: "first", rest: [])) = result
@@ -84,7 +85,7 @@ pub fn and_then_type_change_test() {
     |> validated.and_then(fn(s) {
       case int.parse(s) {
         Ok(n) -> Valid(n)
-        Error(_) -> Invalid(non_empty_list.single("not an int"))
+        Error(Nil) -> Invalid(non_empty_list.single("not an int"))
       }
     })
   let assert Valid(42) = result
@@ -96,7 +97,7 @@ pub fn and_then_chained_test() {
     |> validated.and_then(fn(s) {
       case int.parse(s) {
         Ok(n) -> Valid(n)
-        Error(_) -> Invalid(non_empty_list.single("parse"))
+        Error(Nil) -> Invalid(non_empty_list.single("parse"))
       }
     })
     |> validated.and_then(fn(n) {
@@ -116,6 +117,7 @@ pub fn and_then_does_not_accumulate_test() {
       Invalid(non_empty_list.single("parse failed"))
     })
     |> validated.and_then(fn(_) {
+      // nolint: avoid_panic -- verifies later and_then stages are skipped
       panic as "should not be called after first and_then fails"
     })
   let assert Invalid(NonEmptyList(first: "parse failed", rest: [])) = result

--- a/test/dataprep/validated_test.gleam
+++ b/test/dataprep/validated_test.gleam
@@ -4,96 +4,84 @@ import gleam/int
 
 // --- map ---
 
-pub fn map_valid_test() {
-  let result = Valid(2) |> validated.map(fn(x) { x * 3 })
-  let assert Valid(6) = result
+pub fn map_valid_test() -> Nil {
+  assert Valid(2) |> validated.map(fn(x) { x * 3 }) == Valid(6)
 }
 
-pub fn map_invalid_test() {
-  let result =
-    Invalid(non_empty_list.single("err")) |> validated.map(fn(x) { x * 3 })
-  let assert Invalid(NonEmptyList(first: "err", rest: [])) = result
+pub fn map_invalid_test() -> Nil {
+  assert Invalid(non_empty_list.single("err")) |> validated.map(fn(x) { x * 3 })
+    == Invalid(NonEmptyList(first: "err", rest: []))
 }
 
-pub fn map_type_change_test() {
-  let result = Valid(42) |> validated.map(int.to_string)
-  let assert Valid("42") = result
+pub fn map_type_change_test() -> Nil {
+  assert Valid(42) |> validated.map(int.to_string) == Valid("42")
 }
 
 // --- map_error ---
 
-pub fn map_error_valid_test() {
-  let result =
-    Valid(42) |> validated.map_error(fn(e: String) { "wrapped: " <> e })
-  let assert Valid(42) = result
+pub fn map_error_valid_test() -> Nil {
+  assert Valid(42) |> validated.map_error(fn(e: String) { "wrapped: " <> e })
+    == Valid(42)
 }
 
-pub fn map_error_invalid_test() {
-  let result =
-    Invalid(non_empty_list.single("bad"))
+pub fn map_error_invalid_test() -> Nil {
+  assert Invalid(non_empty_list.single("bad"))
     |> validated.map_error(fn(e) { "wrapped: " <> e })
-  let assert Invalid(NonEmptyList(first: "wrapped: bad", rest: [])) = result
+    == Invalid(NonEmptyList(first: "wrapped: bad", rest: []))
 }
 
-pub fn map_error_multiple_errors_test() {
-  let result =
-    Invalid(NonEmptyList(first: "a", rest: ["b"]))
+pub fn map_error_multiple_errors_test() -> Nil {
+  assert Invalid(NonEmptyList(first: "a", rest: ["b"]))
     |> validated.map_error(fn(e) { "x:" <> e })
-  let assert Invalid(nel) = result
-  let assert ["x:a", "x:b"] = non_empty_list.to_list(nel)
+    == Invalid(NonEmptyList(first: "x:a", rest: ["x:b"]))
 }
 
 // --- and_then ---
 
-pub fn and_then_valid_test() {
-  let result =
-    Valid(10)
+pub fn and_then_valid_test() -> Nil {
+  assert Valid(10)
     |> validated.and_then(fn(x) {
       case x > 5 {
         True -> Valid(x)
         False -> Invalid(non_empty_list.single("too small"))
       }
     })
-  let assert Valid(10) = result
+    == Valid(10)
 }
 
-pub fn and_then_valid_to_invalid_test() {
-  let result =
-    Valid(3)
+pub fn and_then_valid_to_invalid_test() -> Nil {
+  assert Valid(3)
     |> validated.and_then(fn(x) {
       case x > 5 {
         True -> Valid(x)
         False -> Invalid(non_empty_list.single("too small"))
       }
     })
-  let assert Invalid(NonEmptyList(first: "too small", rest: [])) = result
+    == Invalid(NonEmptyList(first: "too small", rest: []))
 }
 
-pub fn and_then_short_circuits_test() {
-  let result =
-    Invalid(non_empty_list.single("first"))
+pub fn and_then_short_circuits_test() -> Nil {
+  assert Invalid(non_empty_list.single("first"))
     |> validated.and_then(fn(_) {
       // nolint: avoid_panic -- verifies and_then short-circuits on Invalid
       panic as "and_then must not call continuation on Invalid"
     })
-  let assert Invalid(NonEmptyList(first: "first", rest: [])) = result
+    == Invalid(NonEmptyList(first: "first", rest: []))
 }
 
-pub fn and_then_type_change_test() {
-  let result =
-    Valid("42")
+pub fn and_then_type_change_test() -> Nil {
+  assert Valid("42")
     |> validated.and_then(fn(s) {
       case int.parse(s) {
         Ok(n) -> Valid(n)
         Error(Nil) -> Invalid(non_empty_list.single("not an int"))
       }
     })
-  let assert Valid(42) = result
+    == Valid(42)
 }
 
-pub fn and_then_chained_test() {
-  let result =
-    Valid("10")
+pub fn and_then_chained_test() -> Nil {
+  assert Valid("10")
     |> validated.and_then(fn(s) {
       case int.parse(s) {
         Ok(n) -> Valid(n)
@@ -106,13 +94,12 @@ pub fn and_then_chained_test() {
         False -> Invalid(non_empty_list.single("positive"))
       }
     })
-  let assert Valid(10) = result
+    == Valid(10)
 }
 
-pub fn and_then_does_not_accumulate_test() {
+pub fn and_then_does_not_accumulate_test() -> Nil {
   // and_then is monadic: first failure stops, second is not run
-  let result =
-    Valid("abc")
+  assert Valid("abc")
     |> validated.and_then(fn(_) {
       Invalid(non_empty_list.single("parse failed"))
     })
@@ -120,185 +107,167 @@ pub fn and_then_does_not_accumulate_test() {
       // nolint: avoid_panic -- verifies later and_then stages are skipped
       panic as "should not be called after first and_then fails"
     })
-  let assert Invalid(NonEmptyList(first: "parse failed", rest: [])) = result
+    == Invalid(NonEmptyList(first: "parse failed", rest: []))
 }
 
 // --- from_result / to_result ---
 
-pub fn from_result_ok_test() {
-  let assert Valid(42) = validated.from_result(Ok(42))
+pub fn from_result_ok_test() -> Nil {
+  assert validated.from_result(Ok(42)) == Valid(42)
 }
 
-pub fn from_result_error_test() {
-  let assert Invalid(NonEmptyList(first: "err", rest: [])) =
-    validated.from_result(Error("err"))
+pub fn from_result_error_test() -> Nil {
+  assert validated.from_result(Error("err"))
+    == Invalid(NonEmptyList(first: "err", rest: []))
 }
 
-pub fn to_result_valid_test() {
-  let assert Ok(42) = validated.to_result(Valid(42))
+pub fn to_result_valid_test() -> Nil {
+  assert validated.to_result(Valid(42)) == Ok(42)
 }
 
-pub fn to_result_invalid_test() {
-  let assert Error(["a", "b"]) =
-    validated.to_result(Invalid(NonEmptyList(first: "a", rest: ["b"])))
+pub fn to_result_invalid_test() -> Nil {
+  assert validated.to_result(Invalid(NonEmptyList(first: "a", rest: ["b"])))
+    == Error(["a", "b"])
 }
 
-pub fn from_result_to_result_roundtrip_ok_test() {
-  let assert Ok(99) = Ok(99) |> validated.from_result |> validated.to_result
+pub fn from_result_to_result_roundtrip_ok_test() -> Nil {
+  assert Ok(99) |> validated.from_result |> validated.to_result == Ok(99)
 }
 
-pub fn from_result_to_result_roundtrip_error_test() {
-  let assert Error(["e"]) =
-    Error("e") |> validated.from_result |> validated.to_result
+pub fn from_result_to_result_roundtrip_error_test() -> Nil {
+  assert Error("e") |> validated.from_result |> validated.to_result
+    == Error(["e"])
 }
 
 // --- map2 ---
 
-pub fn map2_all_valid_test() {
-  let result = validated.map2(fn(a, b) { a + b }, Valid(1), Valid(2))
-  let assert Valid(3) = result
+pub fn map2_all_valid_test() -> Nil {
+  assert validated.map2(fn(a, b) { a + b }, Valid(1), Valid(2)) == Valid(3)
 }
 
-pub fn map2_accumulates_errors_test() {
-  let result =
-    validated.map2(
+pub fn map2_accumulates_errors_test() -> Nil {
+  assert validated.map2(
       fn(a, b) { a + b },
       Invalid(non_empty_list.single("e1")),
       Invalid(non_empty_list.single("e2")),
     )
-  let assert Invalid(nel) = result
-  let assert ["e1", "e2"] = non_empty_list.to_list(nel)
+    == Invalid(NonEmptyList(first: "e1", rest: ["e2"]))
 }
 
-pub fn map2_first_invalid_test() {
-  let result =
-    validated.map2(
+pub fn map2_first_invalid_test() -> Nil {
+  assert validated.map2(
       fn(a, b) { a + b },
       Invalid(non_empty_list.single("e1")),
       Valid(2),
     )
-  let assert Invalid(NonEmptyList(first: "e1", rest: [])) = result
+    == Invalid(NonEmptyList(first: "e1", rest: []))
 }
 
-pub fn map2_second_invalid_test() {
-  let result =
-    validated.map2(
+pub fn map2_second_invalid_test() -> Nil {
+  assert validated.map2(
       fn(a, b) { a + b },
       Valid(1),
       Invalid(non_empty_list.single("e2")),
     )
-  let assert Invalid(NonEmptyList(first: "e2", rest: [])) = result
+    == Invalid(NonEmptyList(first: "e2", rest: []))
 }
 
-pub fn map2_multiple_errors_per_branch_test() {
-  let result =
-    validated.map2(
+pub fn map2_multiple_errors_per_branch_test() -> Nil {
+  assert validated.map2(
       fn(a, b) { a + b },
       Invalid(NonEmptyList(first: "e1a", rest: ["e1b"])),
       Invalid(non_empty_list.single("e2")),
     )
-  let assert Invalid(nel) = result
-  let assert ["e1a", "e1b", "e2"] = non_empty_list.to_list(nel)
+    == Invalid(NonEmptyList(first: "e1a", rest: ["e1b", "e2"]))
 }
 
 // --- map3 ---
 
-pub type Triple {
+type Triple {
   Triple(a: Int, b: Int, c: Int)
 }
 
-pub fn map3_all_valid_test() {
-  let result = validated.map3(Triple, Valid(1), Valid(2), Valid(3))
-  let assert Valid(Triple(1, 2, 3)) = result
+pub fn map3_all_valid_test() -> Nil {
+  assert validated.map3(Triple, Valid(1), Valid(2), Valid(3))
+    == Valid(Triple(1, 2, 3))
 }
 
-pub fn map3_accumulates_errors_test() {
-  let result =
-    validated.map3(
+pub fn map3_accumulates_errors_test() -> Nil {
+  assert validated.map3(
       Triple,
       Invalid(non_empty_list.single("e1")),
       Valid(2),
       Invalid(non_empty_list.single("e3")),
     )
-  let assert Invalid(nel) = result
-  let assert ["e1", "e3"] = non_empty_list.to_list(nel)
+    == Invalid(NonEmptyList(first: "e1", rest: ["e3"]))
 }
 
-pub fn map3_all_invalid_test() {
-  let result =
-    validated.map3(
+pub fn map3_all_invalid_test() -> Nil {
+  assert validated.map3(
       Triple,
       Invalid(non_empty_list.single("e1")),
       Invalid(non_empty_list.single("e2")),
       Invalid(non_empty_list.single("e3")),
     )
-  let assert Invalid(nel) = result
-  let assert ["e1", "e2", "e3"] = non_empty_list.to_list(nel)
+    == Invalid(NonEmptyList(first: "e1", rest: ["e2", "e3"]))
 }
 
-pub fn map3_one_invalid_test() {
-  let result =
-    validated.map3(
+pub fn map3_one_invalid_test() -> Nil {
+  assert validated.map3(
       Triple,
       Valid(1),
       Invalid(non_empty_list.single("e2")),
       Valid(3),
     )
-  let assert Invalid(NonEmptyList(first: "e2", rest: [])) = result
+    == Invalid(NonEmptyList(first: "e2", rest: []))
 }
 
 // --- map4 ---
 
-pub type Quad {
+type Quad {
   Quad(a: Int, b: Int, c: Int, d: Int)
 }
 
-pub fn map4_all_valid_test() {
-  let result = validated.map4(Quad, Valid(1), Valid(2), Valid(3), Valid(4))
-  let assert Valid(Quad(1, 2, 3, 4)) = result
+pub fn map4_all_valid_test() -> Nil {
+  assert validated.map4(Quad, Valid(1), Valid(2), Valid(3), Valid(4))
+    == Valid(Quad(1, 2, 3, 4))
 }
 
-pub fn map4_accumulates_errors_test() {
-  let result =
-    validated.map4(
+pub fn map4_accumulates_errors_test() -> Nil {
+  assert validated.map4(
       Quad,
       Invalid(non_empty_list.single("e1")),
       Invalid(non_empty_list.single("e2")),
       Invalid(non_empty_list.single("e3")),
       Invalid(non_empty_list.single("e4")),
     )
-  let assert Invalid(nel) = result
-  let assert ["e1", "e2", "e3", "e4"] = non_empty_list.to_list(nel)
+    == Invalid(NonEmptyList(first: "e1", rest: ["e2", "e3", "e4"]))
 }
 
-pub fn map4_partial_invalid_test() {
-  let result =
-    validated.map4(
+pub fn map4_partial_invalid_test() -> Nil {
+  assert validated.map4(
       Quad,
       Valid(1),
       Invalid(non_empty_list.single("e2")),
       Valid(3),
       Invalid(non_empty_list.single("e4")),
     )
-  let assert Invalid(nel) = result
-  let assert ["e2", "e4"] = non_empty_list.to_list(nel)
+    == Invalid(NonEmptyList(first: "e2", rest: ["e4"]))
 }
 
 // --- map5 ---
 
-pub type Quint {
+type Quint {
   Quint(a: Int, b: Int, c: Int, d: Int, e: Int)
 }
 
-pub fn map5_all_valid_test() {
-  let result =
-    validated.map5(Quint, Valid(1), Valid(2), Valid(3), Valid(4), Valid(5))
-  let assert Valid(Quint(1, 2, 3, 4, 5)) = result
+pub fn map5_all_valid_test() -> Nil {
+  assert validated.map5(Quint, Valid(1), Valid(2), Valid(3), Valid(4), Valid(5))
+    == Valid(Quint(1, 2, 3, 4, 5))
 }
 
-pub fn map5_accumulates_errors_test() {
-  let result =
-    validated.map5(
+pub fn map5_accumulates_errors_test() -> Nil {
+  assert validated.map5(
       Quint,
       Invalid(non_empty_list.single("e1")),
       Valid(2),
@@ -306,13 +275,11 @@ pub fn map5_accumulates_errors_test() {
       Valid(4),
       Invalid(non_empty_list.single("e5")),
     )
-  let assert Invalid(nel) = result
-  let assert ["e1", "e3", "e5"] = non_empty_list.to_list(nel)
+    == Invalid(NonEmptyList(first: "e1", rest: ["e3", "e5"]))
 }
 
-pub fn map5_all_invalid_test() {
-  let result =
-    validated.map5(
+pub fn map5_all_invalid_test() -> Nil {
+  assert validated.map5(
       Quint,
       Invalid(non_empty_list.single("e1")),
       Invalid(non_empty_list.single("e2")),
@@ -320,13 +287,11 @@ pub fn map5_all_invalid_test() {
       Invalid(non_empty_list.single("e4")),
       Invalid(non_empty_list.single("e5")),
     )
-  let assert Invalid(nel) = result
-  let assert ["e1", "e2", "e3", "e4", "e5"] = non_empty_list.to_list(nel)
+    == Invalid(NonEmptyList(first: "e1", rest: ["e2", "e3", "e4", "e5"]))
 }
 
-pub fn map5_single_invalid_test() {
-  let result =
-    validated.map5(
+pub fn map5_single_invalid_test() -> Nil {
+  assert validated.map5(
       Quint,
       Valid(1),
       Valid(2),
@@ -334,30 +299,26 @@ pub fn map5_single_invalid_test() {
       Invalid(non_empty_list.single("e4")),
       Valid(5),
     )
-  let assert Invalid(NonEmptyList(first: "e4", rest: [])) = result
+    == Invalid(NonEmptyList(first: "e4", rest: []))
 }
 
 // --- error order preservation across mapN ---
 
-pub fn map2_error_order_test() {
-  let result =
-    validated.map2(
+pub fn map2_error_order_test() -> Nil {
+  assert validated.map2(
       fn(a, b) { #(a, b) },
       Invalid(NonEmptyList(first: "first", rest: ["second"])),
       Invalid(non_empty_list.single("third")),
     )
-  let assert Invalid(nel) = result
-  let assert ["first", "second", "third"] = non_empty_list.to_list(nel)
+    == Invalid(NonEmptyList(first: "first", rest: ["second", "third"]))
 }
 
-pub fn map3_error_order_test() {
-  let result =
-    validated.map3(
+pub fn map3_error_order_test() -> Nil {
+  assert validated.map3(
       Triple,
       Invalid(non_empty_list.single("a")),
       Invalid(non_empty_list.single("b")),
       Invalid(non_empty_list.single("c")),
     )
-  let assert Invalid(nel) = result
-  let assert ["a", "b", "c"] = non_empty_list.to_list(nel)
+    == Invalid(NonEmptyList(first: "a", rest: ["b", "c"]))
 }

--- a/test/dataprep/validator_test.gleam
+++ b/test/dataprep/validator_test.gleam
@@ -3,7 +3,7 @@ import dataprep/validated.{Invalid, Valid}
 import dataprep/validator
 import gleam/string
 
-pub type Err {
+type Err {
   TooShort
   TooLong
   IsEmpty
@@ -14,24 +14,27 @@ pub type Err {
 
 // --- check ---
 
-pub fn check_ok_test() {
-  let v = validator.check(fn(_) { Ok(Nil) })
-  let assert Valid("anything") = v("anything")
+pub fn check_ok_test() -> Nil {
+  let validator_under_test = validator.check(fn(_) { Ok(Nil) })
+  assert validator_under_test("anything") == Valid("anything")
 }
 
-pub fn check_error_test() {
-  let v =
+pub fn check_error_test() -> Nil {
+  let validator_under_test =
     validator.check(fn(s: String) {
       case string.length(s) >= 3 {
         True -> Ok(Nil)
         False -> Error(TooShort)
       }
     })
-  let assert Invalid(_) = v("ab")
+  assert case validator_under_test("ab") {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
 }
 
-pub fn check_value_dependent_error_test() {
-  let v =
+pub fn check_value_dependent_error_test() -> Nil {
+  let validator_under_test =
     validator.check(fn(s: String) {
       case string.length(s) {
         0 -> Error(IsEmpty)
@@ -39,86 +42,87 @@ pub fn check_value_dependent_error_test() {
         _ -> Ok(Nil)
       }
     })
-  let assert Invalid(nel) = v("")
-  let assert [IsEmpty] = non_empty_list.to_list(nel)
-  let assert Invalid(nel2) = v("ab")
-  let assert [TooShort] = non_empty_list.to_list(nel2)
-  let assert Valid("abc") = v("abc")
+  assert validator_under_test("") == Invalid(non_empty_list.single(IsEmpty))
+  assert validator_under_test("ab") == Invalid(non_empty_list.single(TooShort))
+  assert validator_under_test("abc") == Valid("abc")
 }
 
 // --- predicate ---
 
-pub fn predicate_pass_test() {
-  let v = validator.predicate(fn(n: Int) { n > 0 }, TooShort)
-  let assert Valid(5) = v(5)
+pub fn predicate_pass_test() -> Nil {
+  let validator_under_test = validator.predicate(fn(n: Int) { n > 0 }, TooShort)
+  assert validator_under_test(5) == Valid(5)
 }
 
-pub fn predicate_fail_test() {
-  let v = validator.predicate(fn(n: Int) { n > 0 }, TooShort)
-  let assert Invalid(_) = v(-1)
+pub fn predicate_fail_test() -> Nil {
+  let validator_under_test = validator.predicate(fn(n: Int) { n > 0 }, TooShort)
+  assert case validator_under_test(-1) {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
 }
 
-pub fn predicate_boundary_test() {
-  let v = validator.predicate(fn(n: Int) { n > 0 }, TooShort)
-  let assert Invalid(_) = v(0)
-  let assert Valid(1) = v(1)
+pub fn predicate_boundary_test() -> Nil {
+  let validator_under_test = validator.predicate(fn(n: Int) { n > 0 }, TooShort)
+  assert case validator_under_test(0) {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
+  assert validator_under_test(1) == Valid(1)
 }
 
 // --- both ---
 
-pub fn both_all_pass_test() {
-  let v =
+pub fn both_all_pass_test() -> Nil {
+  let validator_under_test =
     validator.predicate(fn(s: String) { s != "" }, IsEmpty)
     |> validator.both(
       first: _,
       second: validator.predicate(fn(s) { string.length(s) <= 10 }, TooLong),
     )
-  let assert Valid("hello") = v("hello")
+  assert validator_under_test("hello") == Valid("hello")
 }
 
-pub fn both_accumulates_errors_test() {
+pub fn both_accumulates_errors_test() -> Nil {
   let v1 = validator.predicate(fn(_: String) { False }, TooShort)
   let v2 = validator.predicate(fn(_: String) { False }, TooLong)
-  let v = validator.both(first: v1, second: v2)
-  let assert Invalid(nel) = v("x")
-  let assert [TooShort, TooLong] = non_empty_list.to_list(nel)
+  let validator_under_test = validator.both(first: v1, second: v2)
+  assert validator_under_test("x")
+    == Invalid(non_empty_list.NonEmptyList(first: TooShort, rest: [TooLong]))
 }
 
-pub fn both_first_fails_only_test() {
-  let v =
+pub fn both_first_fails_only_test() -> Nil {
+  let validator_under_test =
     validator.predicate(fn(_: String) { False }, TooShort)
     |> validator.both(
       first: _,
       second: validator.predicate(fn(_) { True }, TooLong),
     )
-  let assert Invalid(nel) = v("x")
-  let assert [TooShort] = non_empty_list.to_list(nel)
+  assert validator_under_test("x") == Invalid(non_empty_list.single(TooShort))
 }
 
-pub fn both_second_fails_only_test() {
-  let v =
+pub fn both_second_fails_only_test() -> Nil {
+  let validator_under_test =
     validator.predicate(fn(_: String) { True }, TooShort)
     |> validator.both(
       first: _,
       second: validator.predicate(fn(_) { False }, TooLong),
     )
-  let assert Invalid(nel) = v("x")
-  let assert [TooLong] = non_empty_list.to_list(nel)
+  assert validator_under_test("x") == Invalid(non_empty_list.single(TooLong))
 }
 
-pub fn both_preserves_input_value_test() {
-  let v =
+pub fn both_preserves_input_value_test() -> Nil {
+  let validator_under_test =
     validator.predicate(fn(s: String) { s != "" }, IsEmpty)
     |> validator.both(
       first: _,
       second: validator.predicate(fn(s) { string.length(s) <= 10 }, TooLong),
     )
-  let assert Valid(result) = v("test")
-  let assert "test" = result
+  assert validator_under_test("test") == Valid("test")
 }
 
-pub fn both_chained_three_test() {
-  let v =
+pub fn both_chained_three_test() -> Nil {
+  let validator_under_test =
     validator.predicate(fn(_: String) { False }, IsEmpty)
     |> validator.both(
       first: _,
@@ -128,94 +132,99 @@ pub fn both_chained_three_test() {
       first: _,
       second: validator.predicate(fn(_) { False }, TooLong),
     )
-  let assert Invalid(nel) = v("x")
-  let assert [IsEmpty, TooShort, TooLong] = non_empty_list.to_list(nel)
+  assert validator_under_test("x")
+    == Invalid(
+      non_empty_list.NonEmptyList(first: IsEmpty, rest: [TooShort, TooLong]),
+    )
 }
 
 // --- all ---
 
-pub fn all_empty_validators_test() {
-  let v = validator.all([])
-  let assert Valid("anything") = v("anything")
+pub fn all_empty_validators_test() -> Nil {
+  let validator_under_test = validator.all([])
+  assert validator_under_test("anything") == Valid("anything")
 }
 
-pub fn all_single_pass_test() {
-  let v = validator.all([validator.predicate(fn(_: String) { True }, IsEmpty)])
-  let assert Valid("x") = v("x")
+pub fn all_single_pass_test() -> Nil {
+  let validator_under_test =
+    validator.all([validator.predicate(fn(_: String) { True }, IsEmpty)])
+  assert validator_under_test("x") == Valid("x")
 }
 
-pub fn all_single_fail_test() {
-  let v = validator.all([validator.predicate(fn(_: String) { False }, IsEmpty)])
-  let assert Invalid(nel) = v("x")
-  let assert [IsEmpty] = non_empty_list.to_list(nel)
+pub fn all_single_fail_test() -> Nil {
+  let validator_under_test =
+    validator.all([validator.predicate(fn(_: String) { False }, IsEmpty)])
+  assert validator_under_test("x") == Invalid(non_empty_list.single(IsEmpty))
 }
 
-pub fn all_accumulates_test() {
-  let v =
+pub fn all_accumulates_test() -> Nil {
+  let validator_under_test =
     validator.all([
       validator.predicate(fn(_: String) { False }, TooShort),
       validator.predicate(fn(_: String) { True }, IsEmpty),
       validator.predicate(fn(_: String) { False }, TooLong),
     ])
-  let assert Invalid(nel) = v("x")
-  let assert [TooShort, TooLong] = non_empty_list.to_list(nel)
+  assert validator_under_test("x")
+    == Invalid(non_empty_list.NonEmptyList(first: TooShort, rest: [TooLong]))
 }
 
-pub fn all_all_fail_test() {
-  let v =
+pub fn all_all_fail_test() -> Nil {
+  let validator_under_test =
     validator.all([
       validator.predicate(fn(_: String) { False }, IsEmpty),
       validator.predicate(fn(_: String) { False }, TooShort),
       validator.predicate(fn(_: String) { False }, TooLong),
     ])
-  let assert Invalid(nel) = v("x")
-  let assert [IsEmpty, TooShort, TooLong] = non_empty_list.to_list(nel)
+  assert validator_under_test("x")
+    == Invalid(
+      non_empty_list.NonEmptyList(first: IsEmpty, rest: [TooShort, TooLong]),
+    )
 }
 
-pub fn all_all_pass_test() {
-  let v =
+pub fn all_all_pass_test() -> Nil {
+  let validator_under_test =
     validator.all([
       validator.predicate(fn(_: String) { True }, IsEmpty),
       validator.predicate(fn(_: String) { True }, TooShort),
     ])
-  let assert Valid("x") = v("x")
+  assert validator_under_test("x") == Valid("x")
 }
 
 // --- alt ---
 
-pub fn alt_first_succeeds_skips_second_test() {
-  let v =
+pub fn alt_first_succeeds_skips_second_test() -> Nil {
+  let validator_under_test =
     validator.predicate(fn(_: String) { True }, NotUuid)
     |> validator.alt(first: _, second: fn(_) {
       // nolint: avoid_panic -- verifies alt short-circuits after success
       panic as "alt must not evaluate second branch when first succeeds"
     })
-  let assert Valid("test") = v("test")
+  assert validator_under_test("test") == Valid("test")
 }
 
-pub fn alt_second_succeeds_test() {
-  let v =
+pub fn alt_second_succeeds_test() -> Nil {
+  let validator_under_test =
     validator.predicate(fn(_: String) { False }, NotUuid)
     |> validator.alt(
       first: _,
       second: validator.predicate(fn(_) { True }, NotSlug),
     )
-  let assert Valid("test") = v("test")
+  assert validator_under_test("test") == Valid("test")
 }
 
-pub fn alt_both_fail_accumulates_test() {
-  let v =
+pub fn alt_both_fail_accumulates_test() -> Nil {
+  let validator_under_test =
     validator.predicate(fn(_: String) { False }, NotUuid)
     |> validator.alt(
       first: _,
       second: validator.predicate(fn(_) { False }, NotSlug),
     )
-  let assert Invalid(nel) = v("test")
-  let assert [NotUuid, NotSlug] = non_empty_list.to_list(nel)
+  assert validator_under_test("test")
+    == Invalid(non_empty_list.NonEmptyList(first: NotUuid, rest: [NotSlug]))
 }
 
-pub fn alt_chained_three_first_wins_test() {
-  let v =
+pub fn alt_chained_three_first_wins_test() -> Nil {
+  let validator_under_test =
     validator.predicate(fn(_: String) { False }, IsEmpty)
     |> validator.alt(
       first: _,
@@ -225,11 +234,11 @@ pub fn alt_chained_three_first_wins_test() {
       // nolint: avoid_panic -- verifies later alt branches are skipped
       panic as "third alt branch should not run"
     })
-  let assert Valid("x") = v("x")
+  assert validator_under_test("x") == Valid("x")
 }
 
-pub fn alt_chained_three_all_fail_test() {
-  let v =
+pub fn alt_chained_three_all_fail_test() -> Nil {
+  let validator_under_test =
     validator.predicate(fn(_: String) { False }, IsEmpty)
     |> validator.alt(
       first: _,
@@ -239,60 +248,60 @@ pub fn alt_chained_three_all_fail_test() {
       first: _,
       second: validator.predicate(fn(_) { False }, TooLong),
     )
-  let assert Invalid(nel) = v("x")
-  let assert [IsEmpty, TooShort, TooLong] = non_empty_list.to_list(nel)
+  assert validator_under_test("x")
+    == Invalid(
+      non_empty_list.NonEmptyList(first: IsEmpty, rest: [TooShort, TooLong]),
+    )
 }
 
 // --- guard ---
 
-pub fn guard_pre_fails_skips_main_test() {
-  let v =
+pub fn guard_pre_fails_skips_main_test() -> Nil {
+  let validator_under_test =
     validator.predicate(fn(s: String) { s != "" }, IsEmpty)
     |> validator.guard(pre: _, main: fn(_) {
       // nolint: avoid_panic -- verifies guard short-circuits on pre failure
       panic as "guard must not evaluate main when pre fails"
     })
-  let assert Invalid(nel) = v("")
-  let assert [IsEmpty] = non_empty_list.to_list(nel)
+  assert validator_under_test("") == Invalid(non_empty_list.single(IsEmpty))
 }
 
-pub fn guard_pre_passes_then_main_runs_test() {
-  let v =
+pub fn guard_pre_passes_then_main_runs_test() -> Nil {
+  let validator_under_test =
     validator.predicate(fn(s: String) { s != "" }, IsEmpty)
     |> validator.guard(
       pre: _,
       main: validator.predicate(fn(_) { False }, TooShort),
     )
-  let assert Invalid(nel) = v("hello")
-  let assert [TooShort] = non_empty_list.to_list(nel)
+  assert validator_under_test("hello")
+    == Invalid(non_empty_list.single(TooShort))
 }
 
-pub fn guard_both_pass_test() {
-  let v =
+pub fn guard_both_pass_test() -> Nil {
+  let validator_under_test =
     validator.predicate(fn(s: String) { s != "" }, IsEmpty)
     |> validator.guard(
       pre: _,
       main: validator.predicate(fn(s) { string.length(s) <= 10 }, TooLong),
     )
-  let assert Valid("hello") = v("hello")
+  assert validator_under_test("hello") == Valid("hello")
 }
 
-pub fn guard_does_not_accumulate_test() {
+pub fn guard_does_not_accumulate_test() -> Nil {
   // guard is short-circuit, NOT accumulation
   // when pre fails, we only see pre's error, not main's
-  let v =
+  let validator_under_test =
     validator.predicate(fn(_: String) { False }, IsEmpty)
     |> validator.guard(
       pre: _,
       main: validator.predicate(fn(_) { False }, TooShort),
     )
-  let assert Invalid(nel) = v("x")
-  let assert [IsEmpty] = non_empty_list.to_list(nel)
+  assert validator_under_test("x") == Invalid(non_empty_list.single(IsEmpty))
 }
 
-pub fn guard_chained_test() {
+pub fn guard_chained_test() -> Nil {
   // guard(non_empty, guard(min_length, max_length))
-  let v =
+  let validator_under_test =
     validator.predicate(fn(s: String) { s != "" }, IsEmpty)
     |> validator.guard(
       pre: _,
@@ -305,76 +314,80 @@ pub fn guard_chained_test() {
           main: validator.predicate(fn(s) { string.length(s) <= 10 }, TooLong),
         ),
     )
-  let assert Invalid(nel) = v("")
-  let assert [IsEmpty] = non_empty_list.to_list(nel)
-  let assert Invalid(nel2) = v("ab")
-  let assert [TooShort] = non_empty_list.to_list(nel2)
-  let assert Valid("abc") = v("abc")
+  assert validator_under_test("") == Invalid(non_empty_list.single(IsEmpty))
+  assert validator_under_test("ab") == Invalid(non_empty_list.single(TooShort))
+  assert validator_under_test("abc") == Valid("abc")
 }
 
 // --- map_error ---
 
-pub fn map_error_test() {
-  let v =
+pub fn map_error_test() -> Nil {
+  let validator_under_test =
     validator.predicate(fn(_: String) { False }, TooShort)
     |> validator.map_error(fn(e) { FieldError("name", e) })
-  let assert Invalid(nel) = v("x")
-  let assert [FieldError("name", TooShort)] = non_empty_list.to_list(nel)
+  assert validator_under_test("x")
+    == Invalid(non_empty_list.single(FieldError("name", TooShort)))
 }
 
-pub fn map_error_valid_passes_through_test() {
-  let v =
+pub fn map_error_valid_passes_through_test() -> Nil {
+  let validator_under_test =
     validator.predicate(fn(_: String) { True }, TooShort)
     |> validator.map_error(fn(e) { FieldError("name", e) })
-  let assert Valid("x") = v("x")
+  assert validator_under_test("x") == Valid("x")
 }
 
-pub fn map_error_multiple_errors_test() {
-  let v =
+pub fn map_error_multiple_errors_test() -> Nil {
+  let validator_under_test =
     validator.predicate(fn(_: String) { False }, TooShort)
     |> validator.both(
       first: _,
       second: validator.predicate(fn(_) { False }, TooLong),
     )
     |> validator.map_error(fn(e) { FieldError("field", e) })
-  let assert Invalid(nel) = v("x")
-  let assert [FieldError("field", TooShort), FieldError("field", TooLong)] =
-    non_empty_list.to_list(nel)
+  assert validator_under_test("x")
+    == Invalid(
+      non_empty_list.NonEmptyList(first: FieldError("field", TooShort), rest: [
+        FieldError("field", TooLong),
+      ]),
+    )
 }
 
 // --- label ---
 
-pub fn label_test() {
-  let v =
+pub fn label_test() -> Nil {
+  let validator_under_test =
     validator.predicate(fn(_: String) { False }, TooShort)
     |> validator.label("user.name", FieldError)
-  let assert Invalid(nel) = v("x")
-  let assert [FieldError("user.name", TooShort)] = non_empty_list.to_list(nel)
+  assert validator_under_test("x")
+    == Invalid(non_empty_list.single(FieldError("user.name", TooShort)))
 }
 
-pub fn label_valid_passes_through_test() {
-  let v =
+pub fn label_valid_passes_through_test() -> Nil {
+  let validator_under_test =
     validator.predicate(fn(_: String) { True }, TooShort)
     |> validator.label("user.name", FieldError)
-  let assert Valid("x") = v("x")
+  assert validator_under_test("x") == Valid("x")
 }
 
-pub fn label_multiple_errors_test() {
-  let v =
+pub fn label_multiple_errors_test() -> Nil {
+  let validator_under_test =
     validator.predicate(fn(_: String) { False }, IsEmpty)
     |> validator.both(
       first: _,
       second: validator.predicate(fn(_) { False }, TooShort),
     )
     |> validator.label("email", FieldError)
-  let assert Invalid(nel) = v("x")
-  let assert [FieldError("email", IsEmpty), FieldError("email", TooShort)] =
-    non_empty_list.to_list(nel)
+  assert validator_under_test("x")
+    == Invalid(
+      non_empty_list.NonEmptyList(first: FieldError("email", IsEmpty), rest: [
+        FieldError("email", TooShort),
+      ]),
+    )
 }
 
 // --- composition: both + alt + guard ---
 
-pub fn both_then_alt_test() {
+pub fn both_then_alt_test() -> Nil {
   // v1: must be non-empty AND short
   // v2: must be non-empty AND long
   // alt: either form is ok
@@ -390,14 +403,14 @@ pub fn both_then_alt_test() {
       first: _,
       second: validator.predicate(fn(s) { string.length(s) >= 10 }, TooShort),
     )
-  let v = validator.alt(first: short, second: long)
+  let validator_under_test = validator.alt(first: short, second: long)
 
-  let assert Valid("ab") = v("ab")
-  let assert Valid("abcdefghijk") = v("abcdefghijk")
+  assert validator_under_test("ab") == Valid("ab")
+  assert validator_under_test("abcdefghijk") == Valid("abcdefghijk")
 }
 
-pub fn guard_then_both_test() {
-  let v =
+pub fn guard_then_both_test() -> Nil {
+  let validator_under_test =
     validator.predicate(fn(s: String) { s != "" }, IsEmpty)
     |> validator.guard(
       pre: _,
@@ -410,7 +423,6 @@ pub fn guard_then_both_test() {
           second: validator.predicate(fn(s) { string.length(s) <= 10 }, TooLong),
         ),
     )
-  let assert Invalid(nel) = v("")
-  let assert [IsEmpty] = non_empty_list.to_list(nel)
-  let assert Valid("hello") = v("hello")
+  assert validator_under_test("") == Invalid(non_empty_list.single(IsEmpty))
+  assert validator_under_test("hello") == Valid("hello")
 }

--- a/test/dataprep/validator_test.gleam
+++ b/test/dataprep/validator_test.gleam
@@ -69,17 +69,17 @@ pub fn predicate_boundary_test() {
 pub fn both_all_pass_test() {
   let v =
     validator.predicate(fn(s: String) { s != "" }, IsEmpty)
-    |> validator.both(validator.predicate(
-      fn(s) { string.length(s) <= 10 },
-      TooLong,
-    ))
+    |> validator.both(
+      first: _,
+      second: validator.predicate(fn(s) { string.length(s) <= 10 }, TooLong),
+    )
   let assert Valid("hello") = v("hello")
 }
 
 pub fn both_accumulates_errors_test() {
   let v1 = validator.predicate(fn(_: String) { False }, TooShort)
   let v2 = validator.predicate(fn(_: String) { False }, TooLong)
-  let v = validator.both(v1, v2)
+  let v = validator.both(first: v1, second: v2)
   let assert Invalid(nel) = v("x")
   let assert [TooShort, TooLong] = non_empty_list.to_list(nel)
 }
@@ -87,7 +87,10 @@ pub fn both_accumulates_errors_test() {
 pub fn both_first_fails_only_test() {
   let v =
     validator.predicate(fn(_: String) { False }, TooShort)
-    |> validator.both(validator.predicate(fn(_) { True }, TooLong))
+    |> validator.both(
+      first: _,
+      second: validator.predicate(fn(_) { True }, TooLong),
+    )
   let assert Invalid(nel) = v("x")
   let assert [TooShort] = non_empty_list.to_list(nel)
 }
@@ -95,7 +98,10 @@ pub fn both_first_fails_only_test() {
 pub fn both_second_fails_only_test() {
   let v =
     validator.predicate(fn(_: String) { True }, TooShort)
-    |> validator.both(validator.predicate(fn(_) { False }, TooLong))
+    |> validator.both(
+      first: _,
+      second: validator.predicate(fn(_) { False }, TooLong),
+    )
   let assert Invalid(nel) = v("x")
   let assert [TooLong] = non_empty_list.to_list(nel)
 }
@@ -103,10 +109,10 @@ pub fn both_second_fails_only_test() {
 pub fn both_preserves_input_value_test() {
   let v =
     validator.predicate(fn(s: String) { s != "" }, IsEmpty)
-    |> validator.both(validator.predicate(
-      fn(s) { string.length(s) <= 10 },
-      TooLong,
-    ))
+    |> validator.both(
+      first: _,
+      second: validator.predicate(fn(s) { string.length(s) <= 10 }, TooLong),
+    )
   let assert Valid(result) = v("test")
   let assert "test" = result
 }
@@ -114,8 +120,14 @@ pub fn both_preserves_input_value_test() {
 pub fn both_chained_three_test() {
   let v =
     validator.predicate(fn(_: String) { False }, IsEmpty)
-    |> validator.both(validator.predicate(fn(_) { False }, TooShort))
-    |> validator.both(validator.predicate(fn(_) { False }, TooLong))
+    |> validator.both(
+      first: _,
+      second: validator.predicate(fn(_) { False }, TooShort),
+    )
+    |> validator.both(
+      first: _,
+      second: validator.predicate(fn(_) { False }, TooLong),
+    )
   let assert Invalid(nel) = v("x")
   let assert [IsEmpty, TooShort, TooLong] = non_empty_list.to_list(nel)
 }
@@ -174,7 +186,8 @@ pub fn all_all_pass_test() {
 pub fn alt_first_succeeds_skips_second_test() {
   let v =
     validator.predicate(fn(_: String) { True }, NotUuid)
-    |> validator.alt(fn(_) {
+    |> validator.alt(first: _, second: fn(_) {
+      // nolint: avoid_panic -- verifies alt short-circuits after success
       panic as "alt must not evaluate second branch when first succeeds"
     })
   let assert Valid("test") = v("test")
@@ -183,14 +196,20 @@ pub fn alt_first_succeeds_skips_second_test() {
 pub fn alt_second_succeeds_test() {
   let v =
     validator.predicate(fn(_: String) { False }, NotUuid)
-    |> validator.alt(validator.predicate(fn(_) { True }, NotSlug))
+    |> validator.alt(
+      first: _,
+      second: validator.predicate(fn(_) { True }, NotSlug),
+    )
   let assert Valid("test") = v("test")
 }
 
 pub fn alt_both_fail_accumulates_test() {
   let v =
     validator.predicate(fn(_: String) { False }, NotUuid)
-    |> validator.alt(validator.predicate(fn(_) { False }, NotSlug))
+    |> validator.alt(
+      first: _,
+      second: validator.predicate(fn(_) { False }, NotSlug),
+    )
   let assert Invalid(nel) = v("test")
   let assert [NotUuid, NotSlug] = non_empty_list.to_list(nel)
 }
@@ -198,16 +217,28 @@ pub fn alt_both_fail_accumulates_test() {
 pub fn alt_chained_three_first_wins_test() {
   let v =
     validator.predicate(fn(_: String) { False }, IsEmpty)
-    |> validator.alt(validator.predicate(fn(_) { True }, TooShort))
-    |> validator.alt(fn(_) { panic as "third alt branch should not run" })
+    |> validator.alt(
+      first: _,
+      second: validator.predicate(fn(_) { True }, TooShort),
+    )
+    |> validator.alt(first: _, second: fn(_) {
+      // nolint: avoid_panic -- verifies later alt branches are skipped
+      panic as "third alt branch should not run"
+    })
   let assert Valid("x") = v("x")
 }
 
 pub fn alt_chained_three_all_fail_test() {
   let v =
     validator.predicate(fn(_: String) { False }, IsEmpty)
-    |> validator.alt(validator.predicate(fn(_) { False }, TooShort))
-    |> validator.alt(validator.predicate(fn(_) { False }, TooLong))
+    |> validator.alt(
+      first: _,
+      second: validator.predicate(fn(_) { False }, TooShort),
+    )
+    |> validator.alt(
+      first: _,
+      second: validator.predicate(fn(_) { False }, TooLong),
+    )
   let assert Invalid(nel) = v("x")
   let assert [IsEmpty, TooShort, TooLong] = non_empty_list.to_list(nel)
 }
@@ -217,7 +248,8 @@ pub fn alt_chained_three_all_fail_test() {
 pub fn guard_pre_fails_skips_main_test() {
   let v =
     validator.predicate(fn(s: String) { s != "" }, IsEmpty)
-    |> validator.guard(fn(_) {
+    |> validator.guard(pre: _, main: fn(_) {
+      // nolint: avoid_panic -- verifies guard short-circuits on pre failure
       panic as "guard must not evaluate main when pre fails"
     })
   let assert Invalid(nel) = v("")
@@ -227,7 +259,10 @@ pub fn guard_pre_fails_skips_main_test() {
 pub fn guard_pre_passes_then_main_runs_test() {
   let v =
     validator.predicate(fn(s: String) { s != "" }, IsEmpty)
-    |> validator.guard(validator.predicate(fn(_) { False }, TooShort))
+    |> validator.guard(
+      pre: _,
+      main: validator.predicate(fn(_) { False }, TooShort),
+    )
   let assert Invalid(nel) = v("hello")
   let assert [TooShort] = non_empty_list.to_list(nel)
 }
@@ -235,10 +270,10 @@ pub fn guard_pre_passes_then_main_runs_test() {
 pub fn guard_both_pass_test() {
   let v =
     validator.predicate(fn(s: String) { s != "" }, IsEmpty)
-    |> validator.guard(validator.predicate(
-      fn(s) { string.length(s) <= 10 },
-      TooLong,
-    ))
+    |> validator.guard(
+      pre: _,
+      main: validator.predicate(fn(s) { string.length(s) <= 10 }, TooLong),
+    )
   let assert Valid("hello") = v("hello")
 }
 
@@ -247,7 +282,10 @@ pub fn guard_does_not_accumulate_test() {
   // when pre fails, we only see pre's error, not main's
   let v =
     validator.predicate(fn(_: String) { False }, IsEmpty)
-    |> validator.guard(validator.predicate(fn(_) { False }, TooShort))
+    |> validator.guard(
+      pre: _,
+      main: validator.predicate(fn(_) { False }, TooShort),
+    )
   let assert Invalid(nel) = v("x")
   let assert [IsEmpty] = non_empty_list.to_list(nel)
 }
@@ -257,11 +295,15 @@ pub fn guard_chained_test() {
   let v =
     validator.predicate(fn(s: String) { s != "" }, IsEmpty)
     |> validator.guard(
-      validator.predicate(fn(s: String) { string.length(s) >= 3 }, TooShort)
-      |> validator.guard(validator.predicate(
-        fn(s) { string.length(s) <= 10 },
-        TooLong,
-      )),
+      pre: _,
+      main: validator.predicate(
+        fn(s: String) { string.length(s) >= 3 },
+        TooShort,
+      )
+        |> validator.guard(
+          pre: _,
+          main: validator.predicate(fn(s) { string.length(s) <= 10 }, TooLong),
+        ),
     )
   let assert Invalid(nel) = v("")
   let assert [IsEmpty] = non_empty_list.to_list(nel)
@@ -290,7 +332,10 @@ pub fn map_error_valid_passes_through_test() {
 pub fn map_error_multiple_errors_test() {
   let v =
     validator.predicate(fn(_: String) { False }, TooShort)
-    |> validator.both(validator.predicate(fn(_) { False }, TooLong))
+    |> validator.both(
+      first: _,
+      second: validator.predicate(fn(_) { False }, TooLong),
+    )
     |> validator.map_error(fn(e) { FieldError("field", e) })
   let assert Invalid(nel) = v("x")
   let assert [FieldError("field", TooShort), FieldError("field", TooLong)] =
@@ -317,7 +362,10 @@ pub fn label_valid_passes_through_test() {
 pub fn label_multiple_errors_test() {
   let v =
     validator.predicate(fn(_: String) { False }, IsEmpty)
-    |> validator.both(validator.predicate(fn(_) { False }, TooShort))
+    |> validator.both(
+      first: _,
+      second: validator.predicate(fn(_) { False }, TooShort),
+    )
     |> validator.label("email", FieldError)
   let assert Invalid(nel) = v("x")
   let assert [FieldError("email", IsEmpty), FieldError("email", TooShort)] =
@@ -332,17 +380,17 @@ pub fn both_then_alt_test() {
   // alt: either form is ok
   let short =
     validator.predicate(fn(s: String) { s != "" }, IsEmpty)
-    |> validator.both(validator.predicate(
-      fn(s) { string.length(s) <= 3 },
-      TooLong,
-    ))
+    |> validator.both(
+      first: _,
+      second: validator.predicate(fn(s) { string.length(s) <= 3 }, TooLong),
+    )
   let long =
     validator.predicate(fn(s: String) { s != "" }, IsEmpty)
-    |> validator.both(validator.predicate(
-      fn(s) { string.length(s) >= 10 },
-      TooShort,
-    ))
-  let v = validator.alt(short, long)
+    |> validator.both(
+      first: _,
+      second: validator.predicate(fn(s) { string.length(s) >= 10 }, TooShort),
+    )
+  let v = validator.alt(first: short, second: long)
 
   let assert Valid("ab") = v("ab")
   let assert Valid("abcdefghijk") = v("abcdefghijk")
@@ -352,11 +400,15 @@ pub fn guard_then_both_test() {
   let v =
     validator.predicate(fn(s: String) { s != "" }, IsEmpty)
     |> validator.guard(
-      validator.predicate(fn(s: String) { string.length(s) >= 3 }, TooShort)
-      |> validator.both(validator.predicate(
-        fn(s) { string.length(s) <= 10 },
-        TooLong,
-      )),
+      pre: _,
+      main: validator.predicate(
+        fn(s: String) { string.length(s) >= 3 },
+        TooShort,
+      )
+        |> validator.both(
+          first: _,
+          second: validator.predicate(fn(s) { string.length(s) <= 10 }, TooLong),
+        ),
     )
   let assert Invalid(nel) = v("")
   let assert [IsEmpty] = non_empty_list.to_list(nel)

--- a/test/dataprep_test.gleam
+++ b/test/dataprep_test.gleam
@@ -1,5 +1,31 @@
+import dataprep.{type NonEmptyList, type Prep, type Validated, type Validator}
+import dataprep/non_empty_list
+import dataprep/prep
+import dataprep/validated
+import dataprep/validator
 import gleeunit
 
+fn api_type_aliases_compile() -> #(
+  Prep(String),
+  Validator(String, Nil),
+  Validated(String, Nil),
+  NonEmptyList(String),
+) {
+  #(
+    prep.identity(),
+    validator.predicate(fn(_: String) { True }, Nil),
+    validated.Valid("ok"),
+    non_empty_list.single("ok"),
+  )
+}
+
 pub fn main() -> Nil {
+  let #(prep_alias, validator_alias, validated_alias, non_empty_list_alias) =
+    api_type_aliases_compile()
+  let assert "ok" = prep_alias("ok")
+  let assert validated.Valid("ok") = validator_alias("ok")
+  let assert validated.Valid("ok") = validated_alias
+  let assert non_empty_list.NonEmptyList(first: "ok", rest: []) =
+    non_empty_list_alias
   gleeunit.main()
 }


### PR DESCRIPTION
## Summary
Add glinter to the Gleam toolchain and wire it into both `just` and GitHub Actions.
The project now runs glinter in strict mode and the codebase has been updated so the linter passes cleanly.

## Changes
- add `glinter` as a dev dependency and configure `[tools.glinter]` with all built-in rules enabled as errors
- add `just lint` and include glinter in `just check` / `just ci`
- update CI and release workflows to install `just` and run the shared recipes
- adjust source and test code for strict glinter rules, using narrow test-only ignores and targeted `nolint` comments where short-circuit tests intentionally use `panic`

## Design Decisions
- keep production code under the strictest rule set, including optional glinter rules such as `function_complexity`, `module_complexity`, `unwrap_used`, `ffi_usage`, and `unused_exports`
- limit test relaxations to rules that conflict with normal test structure (`assert_ok_pattern`, `missing_type_annotation`, `short_variable_name`, `unused_exports`) while keeping the rest of the suite linted
- use `just` as the single entrypoint so local checks and CI stay aligned

## Verification
- `just ci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Validator and data preparation functions now require labeled parameters instead of positional arguments (e.g., `min_length(minimum: 5, error: msg)` instead of `min_length(5, msg)`). Code using these functions must be updated.

* **Code Quality**
  * Added comprehensive linting rules to enforce best practices and catch common errors during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->