### PR TITLE
feat(rules): add matches_string convenience for literal patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- `rules.matches_string(pattern: String, error)` convenience that
+  compiles the pattern internally and panics on a malformed literal.
+  Lets callers with strict glinter settings (`assert_ok_pattern =
+  "error"`) use literal regex patterns without a `let assert
+  Ok(_)` workaround. Dynamic patterns still flow through the
+  existing `matches` + `regexp.from_string` pair so the compile
+  error stays observable. (#5)
+- README example demonstrating both `matches` (dynamic pattern,
+  caller-handled `Result`) and `matches_string` (literal pattern)
+  so first-time users see the compile step that the previous
+  README hid.
+
 ## [0.2.0] - 2026-04-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -202,6 +202,44 @@ pub fn validate_signup(
 //      ])
 ```
 
+### Pattern matching with `rules.matches` / `matches_string`
+
+Use `matches` when the regex is dynamic (built from user input or
+config) — the `regexp.from_string` `Result` stays visible. Use
+`matches_string` when the pattern is a literal at the call site:
+the helper compiles internally and panics on a malformed literal,
+which is a programmer error there is no useful recovery from.
+
+```gleam
+import dataprep/rules
+import dataprep/validated.{type Validated}
+import dataprep/validator
+import gleam/regexp
+
+pub type TagError {
+  BadFormat
+}
+
+// Literal pattern — the convenience helper compiles once at
+// construction. No `let assert Ok(_)` boilerplate at the call site.
+pub fn validate_tag(raw: String) -> Validated(String, TagError) {
+  let check = rules.matches_string(pattern: "^[a-z0-9-]+$", error: BadFormat)
+  check(raw)
+}
+
+// Dynamic pattern — the caller controls the compile error.
+pub fn validate_with(
+  raw: String,
+  pattern: String,
+) -> Result(Validated(String, TagError), regexp.CompileError) {
+  use re <- result.map(regexp.from_string(pattern))
+  rules.matches(pattern: re, error: BadFormat)(raw)
+}
+
+// validate_tag("ok-1") -> Valid("ok-1")
+// validate_tag("BAD!") -> Invalid([BadFormat])
+```
+
 More examples are available in the [doc/recipes/](https://github.com/nao1215/dataprep/tree/main/doc/recipes) directory of the repository.
 
 ## Modules
@@ -212,7 +250,7 @@ More examples are available in the [doc/recipes/](https://github.com/nao1215/dat
 | `dataprep/validator` | Checks without transformation: `check`, `predicate`, `both`, `all`, `alt`, `guard`, `map_error`, `label`, `each`, `optional`. |
 | `dataprep/validated` | Applicative error accumulation: `map`, `map_error`, `and_then`, `from_result`, `from_result_map`, `to_result`, `map2`..`map5`, `sequence`, `traverse`, `traverse_indexed`. |
 | `dataprep/non_empty_list` | At-least-one guarantee for error lists: `single`, `cons`, `append`, `concat`, `map`, `flat_map`, `to_list`, `from_list`. |
-| `dataprep/rules` | Built-in rules: `not_empty`, `not_blank`, `matches`, `min_length`, `max_length`, `length_between`, `min_int`, `max_int`, `min_float`, `max_float`, `non_negative_int`, `non_negative_float`, `one_of`, `equals`. |
+| `dataprep/rules` | Built-in rules: `not_empty`, `not_blank`, `matches`, `matches_string`, `min_length`, `max_length`, `length_between`, `min_int`, `max_int`, `min_float`, `max_float`, `non_negative_int`, `non_negative_float`, `one_of`, `equals`. |
 | `dataprep/parse` | Parse helpers: `int`, `float`. Bridge `String` to typed `Validated` with custom error mapping. |
 
 ## Composition overview

--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ which is a programmer error there is no useful recovery from.
 ```gleam
 import dataprep/rules
 import dataprep/validated.{type Validated}
-import dataprep/validator
 import gleam/regexp
+import gleam/result
 
 pub type TagError {
   BadFormat

--- a/gleam.toml
+++ b/gleam.toml
@@ -50,9 +50,3 @@ unwrap_used = "error"
 
 [tools.glinter.ignore]
 "test/**/*.gleam" = ["unused_exports"]
-# `rules.matches_string` panics at construction time when the
-# inline pattern fails to compile (#5): the only sensible response
-# to a programmer error in a literal regex is to crash, matching
-# the rationale already documented for the `matches` / `matches_string`
-# split.
-"src/dataprep/rules.gleam" = ["avoid_panic"]

--- a/gleam.toml
+++ b/gleam.toml
@@ -50,3 +50,9 @@ unwrap_used = "error"
 
 [tools.glinter.ignore]
 "test/**/*.gleam" = ["unused_exports"]
+# `rules.matches_string` panics at construction time when the
+# inline pattern fails to compile (#5): the only sensible response
+# to a programmer error in a literal regex is to crash, matching
+# the rationale already documented for the `matches` / `matches_string`
+# split.
+"src/dataprep/rules.gleam" = ["avoid_panic"]

--- a/src/dataprep/rules.gleam
+++ b/src/dataprep/rules.gleam
@@ -22,18 +22,56 @@ pub fn not_blank(error: e) -> Validator(String, e) {
 }
 
 /// Fails if the string does not match the given regular expression.
-/// Takes a pre-compiled `Regexp` to avoid runtime crashes from
-/// invalid patterns.
+/// Takes a pre-compiled `Regexp` so a malformed pattern surfaces as a
+/// `regexp.from_string` error at the call site instead of crashing
+/// inside the validator.
 ///
 /// Example:
-///   let assert Ok(re) = regexp.from_string("^[a-z]+$")
-///   rules.matches(pattern: re, error: InvalidFormat)
+///   import gleam/regexp
+///   import dataprep/rules
 ///
+///   let assert Ok(re) = regexp.from_string("^[a-z]+$")
+///   let check = rules.matches(pattern: re, error: InvalidFormat)
+///
+/// For literal patterns where propagating a compile error to the
+/// caller is not useful, see `matches_string`.
 pub fn matches(
   pattern re: regexp.Regexp,
   error error: e,
 ) -> Validator(String, e) {
   validator.predicate(fn(s) { regexp.check(re, s) }, error)
+}
+
+/// Fails if the string does not match the given regular expression
+/// pattern. Compiles the pattern internally; an invalid pattern
+/// panics at construction time with the underlying compile error.
+///
+/// Use this when the pattern is a literal known at the call site
+/// and a compile failure would be a programmer error there is no
+/// meaningful recovery from. For dynamically-supplied patterns,
+/// use `matches` together with `regexp.from_string` so the
+/// `Result` is visible.
+///
+/// Example:
+///   import dataprep/rules
+///
+///   let check = rules.matches_string(
+///     pattern: "^[a-z0-9-]+$",
+///     error: InvalidFormat,
+///   )
+pub fn matches_string(
+  pattern pattern: String,
+  error error: e,
+) -> Validator(String, e) {
+  case regexp.from_string(pattern) {
+    Ok(re) -> matches(pattern: re, error: error)
+    Error(compile_error) -> {
+      let msg =
+        "dataprep/rules.matches_string: invalid pattern — "
+        <> compile_error.error
+      panic as msg
+    }
+  }
 }
 
 /// Fails if the string length is less than min.

--- a/src/dataprep/rules.gleam
+++ b/src/dataprep/rules.gleam
@@ -69,6 +69,7 @@ pub fn matches_string(
       let msg =
         "dataprep/rules.matches_string: invalid pattern — "
         <> compile_error.error
+      // nolint: avoid_panic -- malformed literal regex is a programmer error; recovery is not meaningful at this call site
       panic as msg
     }
   }

--- a/test/dataprep/rules_new_test.gleam
+++ b/test/dataprep/rules_new_test.gleam
@@ -95,9 +95,10 @@ pub fn matches_string_fail_test() -> Nil {
     == Invalid(non_empty_list.single(BadFormat))
 }
 
-pub fn matches_string_compiles_pattern_once_test() -> Nil {
-  // The returned validator is reusable; compilation happens once at
-  // construction, not per element.
+pub fn matches_string_validator_is_reusable_test() -> Nil {
+  // The returned validator can be applied repeatedly. The test
+  // observes reuse, not compile-call counts (the helper compiles at
+  // construction by contract, not by what this test inspects).
   let check = rules.matches_string(pattern: "^[a-z]+$", error: BadFormat)
   assert check("abc") == Valid("abc")
   assert check("ABC") == Invalid(non_empty_list.single(BadFormat))

--- a/test/dataprep/rules_new_test.gleam
+++ b/test/dataprep/rules_new_test.gleam
@@ -81,6 +81,28 @@ pub fn matches_with_guard_test() -> Nil {
   assert validator_under_test("abc") == Valid("abc")
 }
 
+// --- matches_string ---
+
+pub fn matches_string_pass_test() -> Nil {
+  assert rules.matches_string(pattern: "^[a-z0-9]+$", error: BadFormat)(
+      "abc123",
+    )
+    == Valid("abc123")
+}
+
+pub fn matches_string_fail_test() -> Nil {
+  assert rules.matches_string(pattern: "^[a-z]+$", error: BadFormat)("abc123")
+    == Invalid(non_empty_list.single(BadFormat))
+}
+
+pub fn matches_string_compiles_pattern_once_test() -> Nil {
+  // The returned validator is reusable; compilation happens once at
+  // construction, not per element.
+  let check = rules.matches_string(pattern: "^[a-z]+$", error: BadFormat)
+  assert check("abc") == Valid("abc")
+  assert check("ABC") == Invalid(non_empty_list.single(BadFormat))
+}
+
 // --- length_between ---
 
 pub fn length_between_pass_test() -> Nil {


### PR DESCRIPTION
## Summary

`rules.matches` requires a pre-compiled `regexp.Regexp`, but the
README never showed the compile step and offered no convenience for
the common case of a literal pattern. First-time users hit a type
error at the call site, and users on strict glinter settings (the
project's own `assert_ok_pattern = \"error\"`) could not reach for
`let assert Ok(_)` to unwrap `regexp.from_string` cleanly.

This change adds `rules.matches_string(pattern: String, error: e)`
which compiles the pattern internally and panics on a malformed
literal (a programmer error there is no useful recovery from), and
adds a README example pairing it with the existing dynamic-pattern
`matches` so the trade-off is visible at first read.

## Changes

- `src/dataprep/rules.gleam`:
  - New `matches_string` that calls `regexp.from_string` and either
    forwards the compiled regex to the existing `matches`, or panics
    with the underlying compile error message prefixed by the
    function name.
  - Expand the `matches` docstring to point at `matches_string` for
    the literal-pattern case, and clarify when to prefer which.
- `gleam.toml`: add `src/dataprep/rules.gleam` to the glinter
  `avoid_panic` ignore list with a comment explaining why a panic on
  a literal-pattern compile failure is the right shape, mirroring the
  pattern used in sibling packages.
- `test/dataprep/rules_new_test.gleam`: add three tests covering
  pass / fail / reusable-validator-construction for `matches_string`.
- `README.md`:
  - New \"Pattern matching with \`rules.matches\` / \`matches_string\`\"
    example showing both APIs side by side, including the \`use re <-
    result.map(...)\` shape for the dynamic case.
  - Update the Modules table to include \`matches_string\` next to
    \`matches\`.
- `CHANGELOG.md`: note the new rule and the README example under
  \`[Unreleased]\`.

## Design Decisions

- Picked the panic-at-construction approach (Issue's Option 2) over a
  documentation-only fix because the documentation gap was already a
  symptom of an API surface that punished the most common case. A
  worked example fixes discoverability for new readers; the helper
  fixes ergonomics for everyone after that.
- Kept `matches` as the load-bearing primitive and made
  `matches_string` a thin wrapper. The type system still steers
  callers of dynamic patterns through `regexp.from_string` (the
  `Result` is unavoidable there); only the literal-pattern path is
  shortened.
- Panic message is prefixed with `dataprep/rules.matches_string:` so
  a stack trace points at the right function even when the underlying
  compile error is short.
- Validation runs once at construction; per-element calls only invoke
  the cached `regexp.check`, so the steady-state cost matches
  `matches`.

## Limitations

- Non-additive callers are unaffected; this is a pure addition. No
  CHANGELOG breaking-change entry is needed.

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new pattern validation helper for inline regex patterns, reducing complexity for common use cases.

* **Documentation**
  * Enhanced README with side-by-side examples comparing validation approaches.
  * Refined documentation clarifying pattern compilation behavior and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->