### PR TITLE
fix(parse): accept integer literals and scientific notation in float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- `parse.float` is no longer strictly bound to `gleam/float.parse`.
+  It now also accepts integer literals (`"5"` → `5.0`), so the
+  asymmetry with `parse.int` no longer surprises callers who pass a
+  user-typed numeric value, and accepts scientific notation
+  (`"1e3"`, `"1.5e-2"`, `"5E3"`). Inputs the bare stdlib already
+  accepted continue to parse identically; the failure path is
+  unchanged. (#6)
+
 ### Added
 
 - `rules.matches_string(pattern: String, error)` convenience that

--- a/src/dataprep/parse.gleam
+++ b/src/dataprep/parse.gleam
@@ -5,6 +5,8 @@ import dataprep/non_empty_list
 import dataprep/validated.{type Validated, Invalid, Valid}
 import gleam/float
 import gleam/int
+import gleam/result
+import gleam/string
 
 /// Parse a string as Int. On failure, call `on_error` with the
 /// original string to produce the error value.
@@ -22,12 +24,49 @@ pub fn int(raw: String, on_error: fn(String) -> e) -> Validated(Int, e) {
 /// Parse a string as Float. On failure, call `on_error` with the
 /// original string to produce the error value.
 ///
+/// Accepts every shape `gleam/float.parse` accepts (e.g. `"3.14"`,
+/// `"-0.5"`) and additionally accepts:
+///
+/// - integer literals — `"5"` parses as `5.0` (asymmetric strictness
+///   between `parse.int` and `parse.float` was a UX trap when the
+///   raw input is a user-typed numeric value).
+/// - scientific notation — `"1e3"`, `"1.5e-2"`, `"5E3"` are all
+///   accepted; the exponent must itself be a valid integer.
+///
 /// Example:
 ///   parse.float(raw, fn(s) { NotAFloat(s) })
 ///
 pub fn float(raw: String, on_error: fn(String) -> e) -> Validated(Float, e) {
-  case float.parse(raw) {
+  case parse_lenient_float(raw) {
     Ok(x) -> Valid(x)
     Error(Nil) -> Invalid(non_empty_list.single(on_error(raw)))
   }
+}
+
+fn parse_lenient_float(raw: String) -> Result(Float, Nil) {
+  case float.parse(raw) {
+    Ok(x) -> Ok(x)
+    Error(Nil) ->
+      case int.parse(raw) {
+        Ok(n) -> Ok(int.to_float(n))
+        Error(Nil) -> parse_scientific(raw)
+      }
+  }
+}
+
+fn parse_scientific(raw: String) -> Result(Float, Nil) {
+  case string.split_once(string.lowercase(raw), on: "e") {
+    Error(Nil) -> Error(Nil)
+    Ok(#(mantissa_str, exp_str)) -> assemble_scientific(mantissa_str, exp_str)
+  }
+}
+
+fn assemble_scientific(
+  mantissa_str: String,
+  exp_str: String,
+) -> Result(Float, Nil) {
+  use mantissa <- result.try(parse_lenient_float(mantissa_str))
+  use exp <- result.try(int.parse(exp_str))
+  use power <- result.map(float.power(10.0, of: int.to_float(exp)))
+  mantissa *. power
 }

--- a/test/dataprep/parse_test.gleam
+++ b/test/dataprep/parse_test.gleam
@@ -64,6 +64,53 @@ pub fn float_fail_empty_test() -> Nil {
     == Invalid(non_empty_list.single(NotAFloat("")))
 }
 
+// --- parse.float leniency: integer literals (#6) ---
+
+pub fn float_accepts_integer_literal_test() -> Nil {
+  assert parse.float("5", NotAFloat) == Valid(5.0)
+}
+
+pub fn float_accepts_negative_integer_literal_test() -> Nil {
+  assert parse.float("-7", NotAFloat) == Valid(-7.0)
+}
+
+pub fn float_accepts_zero_integer_literal_test() -> Nil {
+  assert parse.float("0", NotAFloat) == Valid(0.0)
+}
+
+// --- parse.float leniency: scientific notation (#6) ---
+
+pub fn float_accepts_scientific_no_decimal_test() -> Nil {
+  assert parse.float("1e3", NotAFloat) == Valid(1000.0)
+}
+
+pub fn float_accepts_scientific_with_decimal_test() -> Nil {
+  assert parse.float("1.5e-2", NotAFloat) == Valid(0.015)
+}
+
+pub fn float_accepts_scientific_uppercase_e_test() -> Nil {
+  assert parse.float("5E3", NotAFloat) == Valid(5000.0)
+}
+
+pub fn float_accepts_scientific_negative_mantissa_test() -> Nil {
+  assert parse.float("-2e2", NotAFloat) == Valid(-200.0)
+}
+
+pub fn float_rejects_scientific_missing_exponent_test() -> Nil {
+  assert parse.float("5e", NotAFloat)
+    == Invalid(non_empty_list.single(NotAFloat("5e")))
+}
+
+pub fn float_rejects_scientific_non_integer_exponent_test() -> Nil {
+  assert parse.float("1e1.5", NotAFloat)
+    == Invalid(non_empty_list.single(NotAFloat("1e1.5")))
+}
+
+pub fn float_rejects_garbage_with_e_test() -> Nil {
+  assert parse.float("abc", NotAFloat)
+    == Invalid(non_empty_list.single(NotAFloat("abc")))
+}
+
 // --- parse + validate pipeline ---
 
 pub fn int_then_validate_test() -> Nil {


### PR DESCRIPTION
## Summary

`parse.float` was a thin wrapper over `gleam/float.parse` and
inherited two strictness rules that surprised callers:

- `parse.float(\"5\", _)` failed even though `parse.int(\"5\", _)` succeeded — the asymmetry was a UX trap when the raw input was a user-typed numeric value with no decimal point.
- Scientific notation (`\"1e3\"`, `\"1.5e-2\"`, `\"5E3\"`) was rejected even though it is a standard float literal shape in most languages.

This change broadens `parse.float` to a small lenient parser that
falls back through three layers: `float.parse` → `int.parse →
to_float` → manual scientific-notation reassembly. The failure path
and the existing-success behaviour are preserved bit-for-bit.

## Changes

- `src/dataprep/parse.gleam`:
  - Replace the single-call body with `parse_lenient_float`, which
    tries `float.parse`, then `int.parse` (promoting to `Float` via
    `int.to_float`), then a `parse_scientific` fallback.
  - `parse_scientific` lower-cases the input, splits on `\"e\"`,
    parses the mantissa via `parse_lenient_float` (so `\"5e3\"`
    reuses the integer-promotion path) and the exponent via
    `int.parse`, and assembles the final value as
    `mantissa *. float.power(10.0, exp)`.
  - Imports added: `gleam/result`, `gleam/string`.
  - Expand the `float` docstring to enumerate the new accepted
    shapes and call out where the leniency stops (the exponent must
    itself be a valid integer; e.g. `\"1e1.5\"` still fails).
- `test/dataprep/parse_test.gleam`:
  - Add nine tests under two headings:
    - integer literals: `\"5\"`, `\"-7\"`, `\"0\"` all promote to
      `Float`.
    - scientific notation: `\"1e3\"`, `\"1.5e-2\"`, `\"5E3\"`,
      `\"-2e2\"` succeed; `\"5e\"`, `\"1e1.5\"`, `\"abc\"` still
      fail and surface the original raw string in the error.
- `CHANGELOG.md`: note the broadened acceptance under
  `[Unreleased]`.

## Design Decisions

- Picked the structural-fallback approach (Issue's first-listed
  suggestion) over a documentation-only fix because the docstring
  alone would not remove the boilerplate users came to dataprep to
  avoid (`\"reduce the boilerplate of int.parse / float.parse\"` is
  the module's stated purpose).
- Promoted integer literals via `int.to_float` rather than a regex /
  string-rewrite because the dedicated stdlib helper is cheaper, more
  obvious, and gives bit-exact integer-to-float conversion for
  values within `Float`'s safe range.
- For scientific notation, reused `parse_lenient_float` recursively
  on the mantissa so a literal like `\"5e3\"` flows through the
  integer-promotion path automatically. Termination is bounded
  because `string.split_once` consumes the only `\"e\"` it splits
  on, so a recursive call cannot reach `parse_scientific` again on
  the same prefix.
- Used `float.power(10.0, exp)` rather than walking the exponent
  with multiplication so the implementation stays linear in source
  size, not exponent magnitude. The single `result.map` keeps the
  error path total without `let assert`.
- Preserved the failure shape: when every fallback fails the
  callback receives the **original** raw string (not the lower-cased
  one), so error messages quote the user's actual input.

## Limitations

- Whitespace is still rejected (`\"  5  \"` does not parse). Callers
  who want trim semantics should chain `prep.trim()` before
  `parse.float`. The whitespace contract is unchanged from the
  previous behaviour.
- This is purely additive at the result level (every previously-
  passing input still passes, with the same value); no breaking
  change.

Closes #6