### PR TITLE
feat(rules): add matches_fully for full-match validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `rules.matches_fully(pattern: regexp.Regexp, error)` and
+  `rules.matches_fully_string(pattern: String, error)` rules that
+  require the regex to match the **entire** input string. Unlike
+  `matches` / `matches_string` (which inherit `regexp.check`'s
+  substring semantics and would accept `"abc123def"` for a digit
+  pattern), the `_fully` variants compare the matched span against
+  the full input. The `matches` / `matches_string` docstrings were
+  also rewritten to call out the substring footgun loudly. This is
+  the validation-friendly default most callers actually wanted. (#7)
 - `rules.matches_string(pattern: String, error)` convenience that
   compiles the pattern internally and panics on a malformed literal.
   Lets callers with strict glinter settings (`assert_ok_pattern =

--- a/README.md
+++ b/README.md
@@ -204,6 +204,14 @@ pub fn validate_signup(
 
 ### Pattern matching with `rules.matches` / `matches_string`
 
+`matches` and `matches_string` use `regexp.check` semantics — they
+pass as long as the pattern hits **anywhere** in the input. A
+pattern like `[0-9]+` will accept `"abc123def"` because the digit
+run matches a substring. For the validation case (\"the **whole**
+string must look like an email / slug / number\"), use the
+`matches_fully` / `matches_fully_string` siblings, which compare
+the matched span against the entire input.
+
 Use `matches` when the regex is dynamic (built from user input or
 config) — the `regexp.from_string` `Result` stays visible. Use
 `matches_string` when the pattern is a literal at the call site:
@@ -220,10 +228,13 @@ pub type TagError {
   BadFormat
 }
 
-// Literal pattern — the convenience helper compiles once at
-// construction. No `let assert Ok(_)` boilerplate at the call site.
+// Literal pattern with full-match semantics — the convenience
+// helper compiles once at construction. No `let assert Ok(_)`
+// boilerplate at the call site, and a substring hit on a partial
+// pattern (like `[a-z0-9-]+`) does NOT silently slip through.
 pub fn validate_tag(raw: String) -> Validated(String, TagError) {
-  let check = rules.matches_string(pattern: "^[a-z0-9-]+$", error: BadFormat)
+  let check =
+    rules.matches_fully_string(pattern: "[a-z0-9-]+", error: BadFormat)
   check(raw)
 }
 
@@ -250,7 +261,7 @@ More examples are available in the [doc/recipes/](https://github.com/nao1215/dat
 | `dataprep/validator` | Checks without transformation: `check`, `predicate`, `both`, `all`, `alt`, `guard`, `map_error`, `label`, `each`, `optional`. |
 | `dataprep/validated` | Applicative error accumulation: `map`, `map_error`, `and_then`, `from_result`, `from_result_map`, `to_result`, `map2`..`map5`, `sequence`, `traverse`, `traverse_indexed`. |
 | `dataprep/non_empty_list` | At-least-one guarantee for error lists: `single`, `cons`, `append`, `concat`, `map`, `flat_map`, `to_list`, `from_list`. |
-| `dataprep/rules` | Built-in rules: `not_empty`, `not_blank`, `matches`, `matches_string`, `min_length`, `max_length`, `length_between`, `min_int`, `max_int`, `min_float`, `max_float`, `non_negative_int`, `non_negative_float`, `one_of`, `equals`. |
+| `dataprep/rules` | Built-in rules: `not_empty`, `not_blank`, `matches`, `matches_string`, `matches_fully`, `matches_fully_string`, `min_length`, `max_length`, `length_between`, `min_int`, `max_int`, `min_float`, `max_float`, `non_negative_int`, `non_negative_float`, `one_of`, `equals`. |
 | `dataprep/parse` | Parse helpers: `int`, `float`. Bridge `String` to typed `Validated` with custom error mapping. |
 
 ## Composition overview

--- a/src/dataprep/rules.gleam
+++ b/src/dataprep/rules.gleam
@@ -1,7 +1,7 @@
 import dataprep/validator.{type Validator}
 import gleam/float
 import gleam/list
-import gleam/regexp
+import gleam/regexp.{Match}
 import gleam/string
 
 /// Fails if the string is exactly "". Whitespace-only strings like
@@ -21,10 +21,22 @@ pub fn not_blank(error: e) -> Validator(String, e) {
   validator.predicate(fn(s) { string.trim(s) != "" }, error)
 }
 
-/// Fails if the string does not match the given regular expression.
-/// Takes a pre-compiled `Regexp` so a malformed pattern surfaces as a
-/// `regexp.from_string` error at the call site instead of crashing
-/// inside the validator.
+/// Fails if the regex does not find a match anywhere in the string.
+/// This is `regexp.check` semantics — a partial / substring match
+/// is enough to pass.
+///
+/// **Anchoring is the caller's responsibility.** A pattern like
+/// `[0-9]+` accepts `"abc123def"` because the digit run matches
+/// somewhere in the input. To require the entire string to match,
+/// either anchor the pattern explicitly with `^...$`, or reach for
+/// `matches_fully` which enforces full-string semantics regardless
+/// of whether the pattern is anchored. The validation use case
+/// almost always wants `matches_fully`; `matches` is exposed for
+/// the cases that genuinely need substring search.
+///
+/// Takes a pre-compiled `Regexp` so a malformed pattern surfaces as
+/// a `regexp.from_string` error at the call site instead of
+/// crashing inside the validator.
 ///
 /// Example:
 ///   import gleam/regexp
@@ -42,9 +54,48 @@ pub fn matches(
   validator.predicate(fn(s) { regexp.check(re, s) }, error)
 }
 
+/// Fails if the regex does not match the entire input string. Unlike
+/// `matches`, a partial / substring hit is **not** enough — the
+/// matched substring must equal the whole input. Equivalent to
+/// Python's `re.fullmatch` semantics.
+///
+/// Anchoring the pattern (`^...$`) is therefore not required: the
+/// validator does the equivalent check itself by comparing the first
+/// match's `content` against the input. Patterns that already include
+/// `^` / `$` continue to work; the anchors just become redundant.
+///
+/// Example:
+///   import gleam/regexp
+///   import dataprep/rules
+///
+///   let assert Ok(re) = regexp.from_string("[0-9]+")
+///   let check = rules.matches_fully(pattern: re, error: NotANumber)
+///
+///   check("123")        // Valid("123")
+///   check("abc123def")  // Invalid([NotANumber])  -- substring match rejected
+pub fn matches_fully(
+  pattern re: regexp.Regexp,
+  error error: e,
+) -> Validator(String, e) {
+  validator.predicate(
+    fn(s) {
+      case regexp.scan(re, s) {
+        [Match(content: c, ..), ..] -> c == s
+        [] -> False
+      }
+    },
+    error,
+  )
+}
+
 /// Fails if the string does not match the given regular expression
 /// pattern. Compiles the pattern internally; an invalid pattern
 /// panics at construction time with the underlying compile error.
+///
+/// **Same anchoring footgun as `matches`**: a pattern like
+/// `"[0-9]+"` accepts `"abc123def"` because the digit run matches
+/// somewhere. Anchor explicitly with `^...$` or use
+/// `matches_fully_string` for the validation case.
 ///
 /// Use this when the pattern is a literal known at the call site
 /// and a compile failure would be a programmer error there is no
@@ -68,6 +119,38 @@ pub fn matches_string(
     Error(compile_error) -> {
       let msg =
         "dataprep/rules.matches_string: invalid pattern — "
+        <> compile_error.error
+      // nolint: avoid_panic -- malformed literal regex is a programmer error; recovery is not meaningful at this call site
+      panic as msg
+    }
+  }
+}
+
+/// Fails if the regex does not match the entire input string.
+/// Compiles the pattern internally; an invalid pattern panics at
+/// construction time with the underlying compile error.
+///
+/// Equivalent to `matches_fully` but with a literal pattern. Use
+/// this for the validation use case — `"[0-9]+"` will reject
+/// `"abc123def"` rather than accepting it on a substring hit, so
+/// the API behaves the way readers usually assume.
+///
+/// Example:
+///   import dataprep/rules
+///
+///   let check = rules.matches_fully_string(
+///     pattern: "[a-z0-9-]+",
+///     error: InvalidFormat,
+///   )
+pub fn matches_fully_string(
+  pattern pattern: String,
+  error error: e,
+) -> Validator(String, e) {
+  case regexp.from_string(pattern) {
+    Ok(re) -> matches_fully(pattern: re, error: error)
+    Error(compile_error) -> {
+      let msg =
+        "dataprep/rules.matches_fully_string: invalid pattern — "
         <> compile_error.error
       // nolint: avoid_panic -- malformed literal regex is a programmer error; recovery is not meaningful at this call site
       panic as msg

--- a/test/dataprep/rules_new_test.gleam
+++ b/test/dataprep/rules_new_test.gleam
@@ -104,6 +104,87 @@ pub fn matches_string_validator_is_reusable_test() -> Nil {
   assert check("ABC") == Invalid(non_empty_list.single(BadFormat))
 }
 
+// --- unanchored matches ---
+//
+// `matches` documents that it is `regexp.check`-shaped: a substring
+// hit is enough. These tests pin that contract so a regression that
+// silently anchors the predicate would fail loudly.
+
+pub fn matches_unanchored_pattern_accepts_substring_hit_test() -> Nil {
+  let pattern = compile_regexp("[0-9]+")
+  assert rules.matches(pattern: pattern, error: BadFormat)("abc123def")
+    == Valid("abc123def")
+}
+
+pub fn matches_string_unanchored_pattern_accepts_substring_hit_test() -> Nil {
+  assert rules.matches_string(pattern: "[0-9]+", error: BadFormat)("abc123def")
+    == Valid("abc123def")
+}
+
+// --- matches_fully ---
+
+pub fn matches_fully_full_match_passes_test() -> Nil {
+  let pattern = compile_regexp("[0-9]+")
+  assert rules.matches_fully(pattern: pattern, error: BadFormat)("123")
+    == Valid("123")
+}
+
+pub fn matches_fully_substring_hit_is_rejected_test() -> Nil {
+  let pattern = compile_regexp("[0-9]+")
+  assert rules.matches_fully(pattern: pattern, error: BadFormat)("abc123def")
+    == Invalid(non_empty_list.single(BadFormat))
+}
+
+pub fn matches_fully_no_match_at_all_is_rejected_test() -> Nil {
+  let pattern = compile_regexp("[0-9]+")
+  assert rules.matches_fully(pattern: pattern, error: BadFormat)("abc")
+    == Invalid(non_empty_list.single(BadFormat))
+}
+
+pub fn matches_fully_already_anchored_pattern_still_works_test() -> Nil {
+  // Patterns that already anchor with ^...$ continue to work — the
+  // anchors just become redundant under `matches_fully`.
+  let pattern = compile_regexp("^[a-z]+$")
+  assert rules.matches_fully(pattern: pattern, error: BadFormat)("abc")
+    == Valid("abc")
+  assert rules.matches_fully(pattern: pattern, error: BadFormat)("abc1")
+    == Invalid(non_empty_list.single(BadFormat))
+}
+
+pub fn matches_fully_empty_input_with_star_pattern_test() -> Nil {
+  // `.*` matches the empty string, and the empty match equals the
+  // empty input — full-match semantics.
+  let pattern = compile_regexp(".*")
+  assert rules.matches_fully(pattern: pattern, error: BadFormat)("")
+    == Valid("")
+}
+
+pub fn matches_fully_empty_input_with_plus_pattern_test() -> Nil {
+  // `.+` requires at least one character; the empty input has no
+  // match at all and is rejected.
+  let pattern = compile_regexp(".+")
+  assert rules.matches_fully(pattern: pattern, error: BadFormat)("")
+    == Invalid(non_empty_list.single(BadFormat))
+}
+
+// --- matches_fully_string ---
+
+pub fn matches_fully_string_pass_test() -> Nil {
+  assert rules.matches_fully_string(pattern: "[a-z0-9-]+", error: BadFormat)(
+      "ok-1",
+    )
+    == Valid("ok-1")
+}
+
+pub fn matches_fully_string_substring_hit_is_rejected_test() -> Nil {
+  // The headline #7 case: literal pattern + substring match must be
+  // rejected by the _fully variant.
+  assert rules.matches_fully_string(pattern: "[0-9]+", error: BadFormat)(
+      "abc123def",
+    )
+    == Invalid(non_empty_list.single(BadFormat))
+}
+
 // --- length_between ---
 
 pub fn length_between_pass_test() -> Nil {


### PR DESCRIPTION
## Summary

`rules.matches` (and the new `matches_string` from #5) used
`regexp.check` semantics, so a pattern like `\"[0-9]+\"` accepted
`\"abc123def\"` because the digit run matched a substring. The
docstring was vague about this — \"fails if the string does not
match\" — and \"match\" reads as full-match to most users coming
from validation libraries.

This change does both halves of the Issue's suggested resolution:

- **Loud documentation**: `matches` / `matches_string` docstrings
  now spell out the substring footgun and link to the new full-match
  variants.
- **Anchored siblings**: new `matches_fully(re: Regexp, ...)` and
  `matches_fully_string(pattern: String, ...)` rules require the
  regex to match the **entire** input string (Python `re.fullmatch`
  semantics), independent of whether the pattern is itself anchored.

## Changes

- `src/dataprep/rules.gleam`:
  - Add `matches_fully` and `matches_fully_string`. Implementation:
    `regexp.scan` then check that the first match's `content` equals
    the whole input, so an already-anchored pattern works
    unchanged and a partial pattern like `\"[0-9]+\"` rejects
    substring hits.
  - Rewrite the `matches` and `matches_string` docstrings to call
    out substring semantics and point at the new variants.
  - Import `gleam/regexp.{Match}` for the destructuring pattern in
    `matches_fully`.
  - `matches_fully_string` reuses the same construction-time panic
    shape (with inline \`// nolint: avoid_panic\` ) introduced for
    `matches_string` in #5.
- `test/dataprep/rules_new_test.gleam`:
  - Add `matches_unanchored_*_accepts_substring_hit_test` cases
    pinning the now-documented `matches` substring contract so a
    regression that silently anchors fails loudly.
  - Add eight `matches_fully*` tests covering full match passes,
    substring rejection (the headline #7 case), no-match-at-all
    rejection, already-anchored patterns, and the empty-input
    edges (`.*` accepts, `.+` rejects).
- `README.md`:
  - New paragraph at the top of the regex section explaining the
    substring vs full-match split before the code example.
  - Update the literal-pattern example to use
    `matches_fully_string` so the README's reference shape is the
    safe default.
  - Add `matches_fully` and `matches_fully_string` to the Modules
    table.
- `CHANGELOG.md`: note the new rules and the docstring rewrite under
  `[Unreleased]`.

## Design Decisions

- Picked the additive approach (Issue's Option 2) over renaming
  `matches` itself. `matches` still has a legitimate use case —
  unanchored substring search exists for a reason — and renaming
  would have been a breaking change without a migration path. The
  pair `matches` / `matches_fully` mirrors how Python's `re` module
  separates `search` from `fullmatch`, which is the model most
  users come in with.
- Implemented `matches_fully` via `regexp.scan` + `content == input`
  rather than wrapping the user's pattern in `^(...)$` because:
  - It works on a pre-compiled `Regexp` value (the API design
    `matches` already chose), so we don't need a separate
    \`Regexp -> Regexp\` recompile path.
  - Patterns that already include `^` / `$` Just Work — the anchors
    become harmlessly redundant rather than creating a malformed
    `^(^foo$)$`.
  - The check is total: a pattern that doesn't compile would already
    have failed at the call site of `regexp.from_string`, so by the
    time we hit the predicate the regex is known-good.
- For `matches_fully_string`, delegated through `matches_fully`
  rather than inlining the scan logic so the two paths share the
  full-match decision in one place.
- The new `matches_fully` predicate compares full-match span by
  string equality. This handles every Unicode case PCRE handles
  identically, since `regexp.scan`'s `content` field already returns
  the matched substring as a Gleam `String`.

## Limitations

- `matches_fully` evaluates the regex once per call (single
  `regexp.scan`) and then does an `O(n)` string equality. For
  pathologically large inputs callers who care about throughput can
  still reach for `matches` with their own anchored pattern. The
  steady-state overhead vs `matches` is one extra string compare
  per element.
- This is purely additive; no existing call site changes shape.

Closes #7