### PR TITLE
chore(release): prepare v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-25
+
 ### Changed
 
 - `parse.float` is no longer strictly bound to `gleam/float.parse`.

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "dataprep"
-version = "0.2.0"
+version = "0.3.0"
 target = "erlang"
 description = "Composable, type-driven preprocessing and validation combinator library"
 licences = ["MIT"]


### PR DESCRIPTION
### Changed

- `parse.float` is no longer strictly bound to `gleam/float.parse`.
  It now also accepts integer literals (`"5"` → `5.0`), so the
  asymmetry with `parse.int` no longer surprises callers who pass a
  user-typed numeric value, and accepts scientific notation
  (`"1e3"`, `"1.5e-2"`, `"5E3"`). Inputs the bare stdlib already
  accepted continue to parse identically; the failure path is
  unchanged. (#6)

### Added

- `rules.matches_fully(pattern: regexp.Regexp, error)` and
  `rules.matches_fully_string(pattern: String, error)` rules that
  require the regex to match the **entire** input string. Unlike
  `matches` / `matches_string` (which inherit `regexp.check`'s
  substring semantics and would accept `"abc123def"` for a digit
  pattern), the `_fully` variants compare the matched span against
  the full input. The `matches` / `matches_string` docstrings were
  also rewritten to call out the substring footgun loudly. This is
  the validation-friendly default most callers actually wanted. (#7)
- `rules.matches_string(pattern: String, error)` convenience that
  compiles the pattern internally and panics on a malformed literal.
  Lets callers with strict glinter settings (`assert_ok_pattern =
  "error"`) use literal regex patterns without a `let assert
  Ok(_)` workaround. Dynamic patterns still flow through the
  existing `matches` + `regexp.from_string` pair so the compile
  error stays observable. (#5)
- README example demonstrating both `matches` (dynamic pattern,
  caller-handled `Result`) and `matches_string` (literal pattern)
  so first-time users see the compile step that the previous
  README hid.
