### PR TITLE
feat: add validated.fail helper for single-error construction

### DIFF
--- a/src/dataprep/validated.gleam
+++ b/src/dataprep/validated.gleam
@@ -7,6 +7,14 @@ pub type Validated(a, e) {
   Invalid(non_empty_list.NonEmptyList(e))
 }
 
+/// Construct an Invalid result from a single error.
+///
+/// Convenience for the common pattern of failing with one error without
+/// manually importing `non_empty_list`.
+pub fn fail(error: e) -> Validated(a, e) {
+  Invalid(non_empty_list.single(error))
+}
+
 /// Transform the success value (functor map).
 pub fn map(v: Validated(a, e), f: fn(a) -> b) -> Validated(b, e) {
   case v {

--- a/test/dataprep/validated_test.gleam
+++ b/test/dataprep/validated_test.gleam
@@ -2,6 +2,17 @@ import dataprep/non_empty_list.{NonEmptyList}
 import dataprep/validated.{Invalid, Valid}
 import gleam/int
 
+// --- fail ---
+
+pub fn fail_returns_invalid_with_single_error_test() -> Nil {
+  let result: validated.Validated(String, String) = validated.fail("oops")
+  assert result == Invalid(NonEmptyList(first: "oops", rest: []))
+}
+
+pub fn fail_is_equivalent_to_manual_construction_test() -> Nil {
+  assert validated.fail(42) == Invalid(non_empty_list.single(42))
+}
+
 // --- map ---
 
 pub fn map_valid_test() -> Nil {


### PR DESCRIPTION
## Summary

Add `validated.fail(error)` convenience function that wraps a single error into `Invalid(NonEmptyList(error))`, eliminating the need to import `non_empty_list` for the most common custom validation pattern.

## Changes

- Add `pub fn fail(error: e) -> Validated(a, e)` to `src/dataprep/validated.gleam`
- Add 2 test cases verifying equivalence with manual construction

## Design Decisions

- Placed near the top of the module (after type definition, before `map`) since it's a constructor
- Named `fail` to mirror common FP patterns (Haskell's `MonadFail`, Scala's `invalid`)

Closes #13