### PR TITLE
chore(release): prepare v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-27
+
+### Added
+
+- `validated.fail(error)` convenience function for constructing an `Invalid`
+  result from a single error without importing `non_empty_list`. (#13)
+
+### Documentation
+
+- Clarify in README that rules return validator functions and must be composed
+  with `validator.both`/`validator.guard`, not piped directly. (#14)
+
 ## [0.3.0] - 2026-04-25
 
 ### Changed

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "dataprep"
-version = "0.3.0"
+version = "0.4.0"
 target = "erlang"
 description = "Composable, type-driven preprocessing and validation combinator library"
 licences = ["MIT"]


### PR DESCRIPTION
### Added

- `validated.fail(error)` convenience function for constructing an `Invalid`
  result from a single error without importing `non_empty_list`. (#13)

### Documentation

- Clarify in README that rules return validator functions and must be composed
  with `validator.both`/`validator.guard`, not piped directly. (#14)
