### PR TITLE
docs(rules): document vacuously unsatisfiable edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- Document the vacuously-unsatisfiable edge cases on `rules.one_of` and
+  `rules.length_between`. `rules.one_of([], error)` and
+  `rules.length_between(min, max, error)` with `min > max` always return
+  `Invalid(error)` for any input — the rule constructors stay pure (no
+  panic, no API break) but the docstrings now flag these as programmer
+  errors and recommend guarding the bounds at the call site when the
+  allowlist or range comes from configuration. Add `length_between` test
+  coverage including a `min > max` regression case so the documented
+  behavior is pinned. (#18)
+
 ## [0.4.0] - 2026-04-27
 
 ### Added

--- a/src/dataprep/rules.gleam
+++ b/src/dataprep/rules.gleam
@@ -169,6 +169,15 @@ pub fn max_length(maximum max: Int, error error: e) -> Validator(String, e) {
 }
 
 /// Fails if the string length is outside [min, max].
+///
+/// Edge case — `min > max`: the resulting validator is vacuously
+/// unsatisfiable (no string length can be both `>= min` and `<= max`),
+/// so every input fails with `error`. This is a programmer error
+/// rather than a runtime condition; the library does not raise it
+/// because rule constructors are pure and never panic. Construct the
+/// rule yourself with a sane range, or guard the bounds at the call
+/// site (e.g., `case min <= max { True -> ...; False -> ... }`) when
+/// `min`/`max` come from configuration or other dynamic input.
 pub fn length_between(
   minimum min: Int,
   maximum max: Int,
@@ -214,6 +223,16 @@ pub fn non_negative_float(error: e) -> Validator(Float, e) {
 }
 
 /// Fails if the value is not in the allowed list.
+///
+/// Edge case — empty `allowed` list: a set-membership check against
+/// the empty set has no inhabitants, so every input fails with
+/// `error`. This is a programmer error rather than a runtime
+/// condition; the library does not raise it because rule constructors
+/// are pure and never panic. Either construct the rule with a
+/// non-empty allowlist, or guard at the call site (e.g.,
+/// `case allowed { [] -> ...; [_, ..] -> rules.one_of(allowed, e) }`)
+/// when the allowlist comes from configuration or other dynamic
+/// input.
 pub fn one_of(allowed allowed: List(a), error error: e) -> Validator(a, e) {
   validator.predicate(fn(a) { list.contains(allowed, a) }, error)
 }

--- a/test/dataprep/rules_test.gleam
+++ b/test/dataprep/rules_test.gleam
@@ -91,6 +91,61 @@ pub fn max_length_empty_string_test() -> Nil {
   assert rules.max_length(maximum: 0, error: TooLong(0))("") == Valid("")
 }
 
+// --- length_between ---
+
+pub fn length_between_pass_test() -> Nil {
+  assert rules.length_between(minimum: 3, maximum: 10, error: TooShort(3))(
+      "hello",
+    )
+    == Valid("hello")
+}
+
+pub fn length_between_below_min_test() -> Nil {
+  assert case
+    rules.length_between(minimum: 3, maximum: 10, error: TooShort(3))("ab")
+  {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
+}
+
+pub fn length_between_above_max_test() -> Nil {
+  assert case
+    rules.length_between(minimum: 3, maximum: 10, error: TooLong(10))(
+      "abcdefghijk",
+    )
+  {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
+}
+
+pub fn length_between_exact_boundaries_test() -> Nil {
+  let between = rules.length_between(minimum: 3, maximum: 5, error: TooShort(3))
+  assert between("abc") == Valid("abc")
+  assert between("abcde") == Valid("abcde")
+}
+
+pub fn length_between_min_greater_than_max_always_fails_test() -> Nil {
+  // Issue #18 — `min > max` defines an empty interval. This test pins the
+  // documented "vacuously fails for any input" behavior so a future
+  // refactor cannot silently change it without surfacing the failure.
+  let between =
+    rules.length_between(minimum: 10, maximum: 3, error: TooShort(10))
+  assert case between("hello") {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
+  assert case between("") {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
+  assert case between("a string of any length") {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
+}
+
 // --- min_int ---
 
 pub fn min_int_pass_test() -> Nil {


### PR DESCRIPTION
## Summary

`rules.one_of([], error)` and `rules.length_between(min, max, error)` with
`min > max` are vacuously unsatisfiable — no input can ever pass — so they
silently always fail. Issue #18 flagged this as a programmer-error footgun
for callers that build rules from configuration or other dynamic data.

The repo's design and `glinter` rules forbid `panic`, the rule
constructors are `pub` and pure, and changing the signatures (e.g. to
require `NonEmptyList`) would be a wide breaking change for a fairly
narrow trap. Document the edge cases in the function docs and pin the
behavior with tests, matching option 3 from the issue.

## Changes

- `src/dataprep/rules.gleam`: extend the docstrings on `one_of` and
  `length_between` with an "Edge case" paragraph that names the
  vacuously-unsatisfiable input, explains why the library does not
  raise (`avoid_panic`, pure constructors), and recommends guarding the
  bounds at the call site for dynamically-built rules.
- `test/dataprep/rules_test.gleam`: add a `--- length_between ---`
  section covering the previously untested rule:
  `length_between_pass_test`, `length_between_below_min_test`,
  `length_between_above_max_test`, `length_between_exact_boundaries_test`,
  and `length_between_min_greater_than_max_always_fails_test`. The last
  pins the documented vacuous-failure behavior across three input
  sizes (empty, mid, long). `one_of_empty_list_always_fails_test`
  already covers the `one_of` side.
- `CHANGELOG.md`: add a `### Documentation` entry under `## [Unreleased]`
  summarizing the change.

## Design Decisions

- **Documentation + tests, not type-level enforcement.** Switching
  `one_of` to take `NonEmptyList(a)` would force every caller's
  signature to grow and break the existing tests, while the
  vacuously-failing case is uncommon. Documenting the contract and
  pinning it with tests keeps the API stable and surfaces the trap in
  the docs that `gleam docs build` produces.
- **No `panic`.** The repo's `glinter` config sets
  `avoid_panic = "error"` and `panic_without_message = "error"`, and
  CLAUDE.md states "Pure functions only". Raising at construction time
  is therefore not an option, even though the issue listed it first —
  the `dataprep` style guide rules it out.
- **Recommend a call-site guard rather than a wrapping helper.** A
  `safe_one_of(allowed, error) -> Result(Validator(a, e), Nil)` would
  also work but expands the API surface for a one-off caller need; the
  call-site `case allowed { [] -> ...; [_, ..] -> rules.one_of(...) }`
  shape is simple to write and keeps the public API minimal (matching
  the "Keep the public API surface small" rule in CLAUDE.md).

Closes #18
