### PR TITLE
chore(release): prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-27
+
 ### Documentation
 
 - Document the vacuously-unsatisfiable edge cases on `rules.one_of` and

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "dataprep"
-version = "0.4.0"
+version = "0.5.0"
 target = "erlang"
 description = "Composable, type-driven preprocessing and validation combinator library"
 licences = ["MIT"]


### PR DESCRIPTION
### Documentation

- Document the vacuously-unsatisfiable edge cases on `rules.one_of` and
  `rules.length_between`. `rules.one_of([], error)` and
  `rules.length_between(min, max, error)` with `min > max` always return
  `Invalid(error)` for any input — the rule constructors stay pure (no
  panic, no API break) but the docstrings now flag these as programmer
  errors and recommend guarding the bounds at the call site when the
  allowlist or range comes from configuration. Add `length_between` test
  coverage including a `min > max` regression case so the documented
  behavior is pinned. (#18)
