### PR TITLE
fix(validator)!: return Validator from each and optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **validator (BREAKING)**: `validator.each` and `validator.optional` now
+  return `Validator(List(a), e)` and `Validator(Option(a), e)` respectively
+  instead of the bare `fn(...) -> Validated(...)` arrows they exposed
+  before. The implementations are unchanged (`each` already preserved
+  its input list per the `Validator` invariant; `optional` already
+  preserved its `Option`), but the explicit `Validator(_, _)` return
+  type means both can now be dropped directly into `validator.all`,
+  `validator.both`, `validator.alt`, and `validator.guard` over the
+  same parent value — the seven-line bridge described in #21 (validate
+  `length(list) <= 8` AND `each item satisfies X` over the same
+  `List(String)`) collapses to a one-line `validator.all([...])`
+  composition. Existing call sites that captured the bound function
+  by its concrete type need no change because the alias resolves
+  transparently; sites that named the type explicitly should switch
+  to `Validator(List(a), e)` / `Validator(Option(a), e)`. (#21)
+
 ## [0.5.0] - 2026-04-27
 
 ### Documentation

--- a/src/dataprep/validator.gleam
+++ b/src/dataprep/validator.gleam
@@ -1,6 +1,7 @@
 import dataprep/non_empty_list
 import dataprep/validated.{type Validated, Invalid, Valid}
 import gleam/list
+import gleam/option
 
 /// Validator(a, e) checks a value and either returns it unchanged
 /// or produces errors. Key invariant: if v(x) returns Valid(y), then x == y.
@@ -145,20 +146,30 @@ pub fn label(
 /// All errors from all elements are accumulated.
 /// Returns Valid with the unchanged list on success.
 ///
+/// Issue #21: returns a `Validator(List(a), e)` so it composes
+/// directly with `all`, `both`, `alt`, and `guard` over the same
+/// parent list — e.g. `validator.all([length_check, validator.each(item_v)])`
+/// validates "this list as a whole" AND "each item" without an
+/// adapter. The Validator invariant (input value preserved on
+/// Valid) holds because `validated.traverse` does not mutate the
+/// input — it threads each element through `v` whose own invariant
+/// preserves the value.
+///
 /// For index-aware validation, use `validated.traverse_indexed`
 /// with `validator.label` to attach position info.
-pub fn each(
-  v: Validator(a, e),
-) -> fn(List(a)) -> validated.Validated(List(a), e) {
+pub fn each(v: Validator(a, e)) -> Validator(List(a), e) {
   fn(items) { validated.traverse(items, v) }
 }
 
 /// Make a validator optional: if the value is None, it is always
 /// Valid(None). If Some(a), run the inner validator and wrap the
 /// result back in Some.
-pub fn optional(
-  v: Validator(a, e),
-) -> fn(option.Option(a)) -> validated.Validated(option.Option(a), e) {
+///
+/// Issue #21: returns a `Validator(Option(a), e)` so it composes
+/// with `all`, `both`, `alt`, and `guard` over the same optional
+/// parent value (e.g. enforce "if present, satisfies X" alongside
+/// other Optional-level rules).
+pub fn optional(v: Validator(a, e)) -> Validator(option.Option(a), e) {
   fn(opt) {
     case opt {
       option.None -> Valid(option.None)
@@ -166,5 +177,3 @@ pub fn optional(
     }
   }
 }
-
-import gleam/option

--- a/test/dataprep/validator_test.gleam
+++ b/test/dataprep/validator_test.gleam
@@ -1,6 +1,8 @@
 import dataprep/non_empty_list
 import dataprep/validated.{Invalid, Valid}
 import dataprep/validator
+import gleam/list
+import gleam/option
 import gleam/string
 
 type Err {
@@ -425,4 +427,86 @@ pub fn guard_then_both_test() -> Nil {
     )
   assert validator_under_test("") == Invalid(non_empty_list.single(IsEmpty))
   assert validator_under_test("hello") == Valid("hello")
+}
+
+// --- each composes with all/both/alt/guard (issue #21) ---
+
+/// Issue #21 reproduction: validate "≤ N items in the list" AND
+/// "each item satisfies X" using `validator.all` over a single
+/// `Validator(List(a), e)`. Before the fix, `each` returned the
+/// raw `fn(List(a)) -> Validated(...)` arrow which forced callers
+/// to write a 7-line bridge to lift it back into `Validator`.
+pub fn each_composes_with_all_over_parent_list_test() -> Nil {
+  let item_v = validator.predicate(fn(s: String) { s != "" }, IsEmpty)
+  let validator_under_test =
+    validator.all([
+      validator.predicate(
+        fn(items: List(String)) { list.length(items) <= 3 },
+        TooLong,
+      ),
+      validator.each(item_v),
+    ])
+
+  // Happy path: list ≤ 3 and every item is non-empty.
+  assert validator_under_test(["a", "b"]) == Valid(["a", "b"])
+
+  // Single failure: parent rule fails (too many items), per-item
+  // rule passes — only TooLong surfaces.
+  assert validator_under_test(["a", "b", "c", "d"])
+    == Invalid(non_empty_list.single(TooLong))
+
+  // Single failure: parent rule passes, per-item rule fails on one
+  // element — only IsEmpty surfaces.
+  assert validator_under_test(["a", "", "b"])
+    == Invalid(non_empty_list.single(IsEmpty))
+}
+
+/// Confirms `each` now composes with `both` exactly like any other
+/// `Validator(List(a), e)` would.
+pub fn each_composes_with_both_over_parent_list_test() -> Nil {
+  let item_v = validator.predicate(fn(s: String) { s != "" }, IsEmpty)
+  let validator_under_test =
+    validator.both(
+      first: validator.predicate(
+        fn(items: List(String)) { list.length(items) <= 3 },
+        TooLong,
+      ),
+      second: validator.each(item_v),
+    )
+
+  assert validator_under_test(["a"]) == Valid(["a"])
+
+  // Both rules fail: errors accumulate.
+  assert case validator_under_test(["", "", "", ""]) {
+    Invalid(_) -> True
+    Valid(_) -> False
+  }
+}
+
+// --- optional composes with all/both/alt/guard (issue #21) ---
+
+/// Mirror of #21 for `optional`: returns a `Validator(Option(a), e)`
+/// so it can sit in an `all` list alongside other Optional-level
+/// rules without an adapter wrapper.
+pub fn optional_composes_with_all_over_parent_option_test() -> Nil {
+  let inner =
+    validator.predicate(fn(s: String) { string.length(s) >= 3 }, TooShort)
+  let validator_under_test =
+    validator.all([
+      validator.predicate(option.is_some, IsEmpty),
+      validator.optional(inner),
+    ])
+
+  // Some + valid inner → both rules pass.
+  assert validator_under_test(option.Some("hello"))
+    == Valid(option.Some("hello"))
+
+  // None → presence check fails, optional inner short-circuits to
+  // Valid(None). Only IsEmpty surfaces.
+  assert validator_under_test(option.None)
+    == Invalid(non_empty_list.single(IsEmpty))
+
+  // Some but inner fails → presence check passes, inner fails.
+  assert validator_under_test(option.Some("ab"))
+    == Invalid(non_empty_list.single(TooShort))
 }


### PR DESCRIPTION
## Summary

Fixes Issue #21. The library has `validator.each` for per-element
rules and `validator.all` / `validator.both` for combining multiple
rules over a single value, but they couldn't be composed in the
natural way: `each` returned a bare `fn(List(a)) -> Validated(...)`
arrow rather than a `Validator(List(a), e)`, so users had to write a
seven-line bridge to validate "length of list ≤ N" AND "each item
satisfies X" over the same `List(String)`.

The implementations of `each` and `optional` were already
Validator-shaped — they preserved their input value per the
`Validator` invariant. Only the explicit return type annotation
prevented direct composition. This PR fixes the annotations:

```gleam
// Before
pub fn each(v: Validator(a, e)) -> fn(List(a)) -> validated.Validated(List(a), e)
pub fn optional(v: Validator(a, e)) -> fn(option.Option(a)) -> validated.Validated(option.Option(a), e)

// After
pub fn each(v: Validator(a, e)) -> Validator(List(a), e)
pub fn optional(v: Validator(a, e)) -> Validator(option.Option(a), e)
```

The natural composition the user wanted now type-checks:

```gleam
fn tags_validator() -> validator.Validator(List(String), FieldError) {
  validator.all([
    validator.predicate(
      fn(ts) { list.length(ts) <= 8 },
      FieldError("tags", "too many"),
    ),
    validator.each(single_tag_validator()),
  ])
}
```

## Changes

- `src/dataprep/validator.gleam`:
  - `each` and `optional` return `Validator(List(a), e)` /
    `Validator(Option(a), e)`.
  - Moved the misplaced `import gleam/option` from the bottom of the
    file up to the import block (cleanup).
  - Doc-comment additions point future readers at the composition
    examples.
- `test/dataprep/validator_test.gleam`: three new regression tests
  cover the issue's exact pattern — `each` composed with
  `validator.all` (length + per-item rules), `each` composed with
  `validator.both`, and `optional` composed with `validator.all` over
  an `Option(String)` parent.
- `CHANGELOG.md`: documented as breaking under `### Changed`.

## Design Decisions

- **Type-rename only, no implementation change.** `validated.traverse`
  (used by `each`) doesn't mutate its input list, and `validated.map`
  in `optional`'s `Some(a)` arm wraps the unchanged inner value.
  Both functions already satisfied the Validator invariant, so the
  fix is a one-token edit per signature plus the doc-comment.
- **Marked breaking.** Existing call sites that captured the bound
  function by its concrete `fn(...) -> Validated(...)` type need no
  change because Gleam type aliases unify transparently. Sites that
  named the type explicitly should switch to `Validator(_, _)`.
  Conservatively flagged as breaking in the CHANGELOG.

## Test Plan

- [x] `just check` — 242 passes (3 new regression tests for #21);
  format-check, glinter, gleam check, build (warnings-as-errors),
  test all green.
- [x] Confirmed the issue's exact "natural shape" (`validator.all
  ([length_check, validator.each(item_v)])`) type-checks and
  evaluates correctly in the new tests, including error
  accumulation and value preservation.

Closes #21
