### PR TITLE
chore(release): prepare v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-28
+
 ### Changed
 
 - **validator (BREAKING)**: `validator.each` and `validator.optional` now

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "dataprep"
-version = "0.5.0"
+version = "0.6.0"
 target = "erlang"
 description = "Composable, type-driven preprocessing and validation combinator library"
 licences = ["MIT"]


### PR DESCRIPTION
## Release v0.6.0

One breaking change: `validator.each` and `validator.optional` now
return `Validator(_, _)` so they compose directly with the rest of
the validator combinator family.

### Highlights — `BREAKING` for explicit type annotations only

- **`validator.each` and `validator.optional` return `Validator`
  (#21).** Both functions previously exposed bare
  `fn(...) -> Validated(...)` arrows that couldn't sit inside
  `validator.all` / `validator.both` / `validator.alt` /
  `validator.guard` over the same parent value without a custom
  bridge. The implementations were already Validator-shaped
  (input value preserved on Valid), so the fix is a return type
  rename:
  - `each(v: Validator(a, e)) -> Validator(List(a), e)`
  - `optional(v: Validator(a, e)) -> Validator(Option(a), e)`

  Existing call sites that captured the bound function by its
  concrete type need no change because Gleam type aliases unify
  transparently. Sites that named the type explicitly (e.g.
  `fn(List(String)) -> Validated(List(String), Err)`) should
  switch to `Validator(List(String), Err)` (or `Validator(Option(_), _)`
  for `optional`).

  After the change, the natural composition pattern type-checks
  out of the box:

  ```gleam
  fn tags_validator() -> validator.Validator(List(String), FieldError) {
    validator.all([
      validator.predicate(
        fn(ts) { list.length(ts) <= 8 },
        FieldError("tags", "too many"),
      ),
      validator.each(single_tag_validator()),
    ])
  }
  ```

### Coverage

- 247 unit tests (up from 244 on v0.5.0); 3 new regression tests
  pin the `each` + `all` / `each` + `both` / `optional` + `all`
  composition shapes that #21 described.
- `just check` (format-check + glinter + typecheck + warnings-as-errors
  build + test) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
