### PR TITLE
refactor(non_empty_list): make NonEmptyList opaque and add accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **non_empty_list (BREAKING)**: `NonEmptyList(a)` is now `pub opaque`.
+  Direct constructor calls like `NonEmptyList(first: x, rest: [...])`
+  and pattern matches on the `NonEmptyList` constructor no longer
+  compile. Construct via `non_empty_list.single`,
+  `non_empty_list.cons`, or `non_empty_list.from_list`; observe via
+  `non_empty_list.head`, `non_empty_list.tail`,
+  `non_empty_list.to_list`, or `non_empty_list.fold`. Hiding the
+  representation lets the internal layout evolve without a future
+  breaking change. (#26)
+
+### Added
+
+- `non_empty_list.head`, `non_empty_list.tail`, `non_empty_list.length`,
+  `non_empty_list.fold`, and `non_empty_list.reverse` accessors so
+  callers can observe a `NonEmptyList` without pattern matching.
+  `head` is total, `tail` returns a plain `List(a)` (possibly empty),
+  `length` is always `>= 1`, `fold` mirrors `gleam/list.fold` with
+  `from:` / `with:` labels, and `reverse` returns a `NonEmptyList(a)`.
+  (#26)
+- Module-level docstring on `dataprep/validated` clarifying that
+  `Validated(a, e)` is intentionally a transparent sum type and that
+  pattern matching on `Valid` / `Invalid` is the supported call
+  shape. (#26)
+
 ## [0.6.0] - 2026-04-28
 
 ### Changed

--- a/src/dataprep/non_empty_list.gleam
+++ b/src/dataprep/non_empty_list.gleam
@@ -1,6 +1,13 @@
+import gleam/list
+
 /// NonEmptyList guarantees at least one element.
 /// Used by Invalid to ensure every failure carries at least one error.
-pub type NonEmptyList(a) {
+///
+/// The type is opaque: callers construct values via `single` / `cons` /
+/// `from_list` and observe values via `head` / `tail` / `to_list` /
+/// `fold` / `length` / `reverse`. Hiding the constructor lets the
+/// internal representation evolve without a breaking release.
+pub opaque type NonEmptyList(a) {
   NonEmptyList(first: a, rest: List(a))
 }
 
@@ -59,4 +66,30 @@ pub fn from_list(l: List(a)) -> Result(NonEmptyList(a), Nil) {
   }
 }
 
-import gleam/list
+/// Return the first element. Total: a NonEmptyList always has one.
+pub fn head(nel: NonEmptyList(a)) -> a {
+  nel.first
+}
+
+/// Return everything after the first element as a plain List.
+/// May be empty when the NonEmptyList holds a single element.
+pub fn tail(nel: NonEmptyList(a)) -> List(a) {
+  nel.rest
+}
+
+/// Return the number of elements. Always >= 1.
+pub fn length(nel: NonEmptyList(a)) -> Int {
+  list.length(to_list(nel))
+}
+
+/// Fold over every item from an initial accumulator.
+pub fn fold(nel: NonEmptyList(a), from initial: b, with f: fn(b, a) -> b) -> b {
+  list.fold(over: to_list(nel), from: initial, with: f)
+}
+
+/// Reverse the order of elements. The result is itself a NonEmptyList.
+pub fn reverse(nel: NonEmptyList(a)) -> NonEmptyList(a) {
+  list.fold(over: nel.rest, from: single(nel.first), with: fn(acc, item) {
+    cons(head: item, tail: acc)
+  })
+}

--- a/src/dataprep/validated.gleam
+++ b/src/dataprep/validated.gleam
@@ -1,3 +1,7 @@
+/// Validated(a, e) is intentionally a transparent sum type. Pattern
+/// matching on `Valid(_)` and `Invalid(_)` is the supported call shape:
+/// it is the natural way to consume a result without a redundant
+/// extractor layer, and the constructors are part of the stable API.
 import dataprep/non_empty_list
 import gleam/list
 

--- a/test/dataprep/helpers/nel.gleam
+++ b/test/dataprep/helpers/nel.gleam
@@ -1,0 +1,11 @@
+import dataprep/non_empty_list.{type NonEmptyList}
+
+/// Test helper: build a NonEmptyList from `first` and a `rest` list.
+/// Construction goes through the public `from_list` API; the
+/// `[first, ..rest]` input is structurally non-empty so the unwrap
+/// branch is unreachable.
+pub fn make(first first: a, rest rest: List(a)) -> NonEmptyList(a) {
+  // nolint: assert_ok_pattern -- [first, ..rest] is non-empty by construction
+  let assert Ok(value) = non_empty_list.from_list([first, ..rest])
+  value
+}

--- a/test/dataprep/non_empty_list_test.gleam
+++ b/test/dataprep/non_empty_list_test.gleam
@@ -1,9 +1,10 @@
-import dataprep/non_empty_list.{NonEmptyList}
+import dataprep/helpers/nel
+import dataprep/non_empty_list
 
 // --- single ---
 
 pub fn single_test() -> Nil {
-  assert non_empty_list.single(1) == NonEmptyList(first: 1, rest: [])
+  assert non_empty_list.single(1) == nel.make(first: 1, rest: [])
 }
 
 pub fn single_string_test() -> Nil {
@@ -14,7 +15,7 @@ pub fn single_string_test() -> Nil {
 
 pub fn cons_test() -> Nil {
   assert non_empty_list.single(2) |> non_empty_list.cons(head: 1, tail: _)
-    == NonEmptyList(first: 1, rest: [2])
+    == nel.make(first: 1, rest: [2])
 }
 
 pub fn cons_multiple_test() -> Nil {
@@ -28,10 +29,10 @@ pub fn cons_multiple_test() -> Nil {
 // --- append ---
 
 pub fn append_test() -> Nil {
-  let left = NonEmptyList(first: 1, rest: [2])
-  let right = NonEmptyList(first: 3, rest: [4])
+  let left = nel.make(first: 1, rest: [2])
+  let right = nel.make(first: 3, rest: [4])
   assert non_empty_list.append(left: left, right: right)
-    == NonEmptyList(first: 1, rest: [2, 3, 4])
+    == nel.make(first: 1, rest: [2, 3, 4])
 }
 
 pub fn append_single_to_single_test() -> Nil {
@@ -44,8 +45,8 @@ pub fn append_single_to_single_test() -> Nil {
 }
 
 pub fn append_preserves_order_test() -> Nil {
-  let left = NonEmptyList(first: "a", rest: ["b"])
-  let right = NonEmptyList(first: "c", rest: ["d"])
+  let left = nel.make(first: "a", rest: ["b"])
+  let right = nel.make(first: "c", rest: ["d"])
   assert non_empty_list.to_list(non_empty_list.append(left: left, right: right))
     == ["a", "b", "c", "d"]
 }
@@ -53,25 +54,24 @@ pub fn append_preserves_order_test() -> Nil {
 // --- concat ---
 
 pub fn concat_test() -> Nil {
-  let first_group = NonEmptyList(first: 1, rest: [2])
-  let second_group = NonEmptyList(first: 3, rest: [])
-  let third_group = NonEmptyList(first: 4, rest: [5])
-  let groups =
-    NonEmptyList(first: first_group, rest: [second_group, third_group])
+  let first_group = nel.make(first: 1, rest: [2])
+  let second_group = nel.make(first: 3, rest: [])
+  let third_group = nel.make(first: 4, rest: [5])
+  let groups = nel.make(first: first_group, rest: [second_group, third_group])
   assert non_empty_list.concat(groups) |> non_empty_list.to_list
     == [1, 2, 3, 4, 5]
 }
 
 pub fn concat_single_list_test() -> Nil {
-  let inner = NonEmptyList(first: 42, rest: [])
-  let groups = NonEmptyList(first: inner, rest: [])
+  let inner = nel.make(first: 42, rest: [])
+  let groups = nel.make(first: inner, rest: [])
   assert non_empty_list.concat(groups) |> non_empty_list.to_list == [42]
 }
 
 // --- map ---
 
 pub fn map_test() -> Nil {
-  let values = NonEmptyList(first: 1, rest: [2, 3])
+  let values = nel.make(first: 1, rest: [2, 3])
   assert non_empty_list.map(values, fn(x) { x * 2 }) |> non_empty_list.to_list
     == [2, 4, 6]
 }
@@ -83,7 +83,7 @@ pub fn map_single_test() -> Nil {
 }
 
 pub fn map_type_change_test() -> Nil {
-  let values = NonEmptyList(first: 1, rest: [2, 3])
+  let values = nel.make(first: 1, rest: [2, 3])
   assert non_empty_list.map(values, fn(x) { x > 1 }) |> non_empty_list.to_list
     == [False, True, True]
 }
@@ -91,9 +91,9 @@ pub fn map_type_change_test() -> Nil {
 // --- flat_map ---
 
 pub fn flat_map_test() -> Nil {
-  let values = NonEmptyList(first: 1, rest: [2])
+  let values = nel.make(first: 1, rest: [2])
   assert non_empty_list.flat_map(values, fn(x) {
-      NonEmptyList(first: x, rest: [x * 10])
+      nel.make(first: x, rest: [x * 10])
     })
     |> non_empty_list.to_list
     == [1, 10, 2, 20]
@@ -102,7 +102,7 @@ pub fn flat_map_test() -> Nil {
 pub fn flat_map_single_test() -> Nil {
   let value = non_empty_list.single(5)
   assert non_empty_list.flat_map(value, fn(x) {
-      NonEmptyList(first: x, rest: [x + 1])
+      nel.make(first: x, rest: [x + 1])
     })
     |> non_empty_list.to_list
     == [5, 6]
@@ -111,7 +111,7 @@ pub fn flat_map_single_test() -> Nil {
 // --- to_list ---
 
 pub fn to_list_test() -> Nil {
-  let values = NonEmptyList(first: "a", rest: ["b", "c"])
+  let values = nel.make(first: "a", rest: ["b", "c"])
   assert non_empty_list.to_list(values) == ["a", "b", "c"]
 }
 
@@ -127,12 +127,11 @@ pub fn from_list_empty_test() -> Nil {
 
 pub fn from_list_non_empty_test() -> Nil {
   assert non_empty_list.from_list([1, 2, 3])
-    == Ok(NonEmptyList(first: 1, rest: [2, 3]))
+    == Ok(nel.make(first: 1, rest: [2, 3]))
 }
 
 pub fn from_list_single_element_test() -> Nil {
-  assert non_empty_list.from_list(["x"])
-    == Ok(NonEmptyList(first: "x", rest: []))
+  assert non_empty_list.from_list(["x"]) == Ok(nel.make(first: "x", rest: []))
 }
 
 // --- roundtrip ---
@@ -140,5 +139,87 @@ pub fn from_list_single_element_test() -> Nil {
 pub fn from_list_to_list_roundtrip_test() -> Nil {
   let original = [1, 2, 3, 4, 5]
   assert non_empty_list.from_list(original)
-    == Ok(NonEmptyList(first: 1, rest: [2, 3, 4, 5]))
+    == Ok(nel.make(first: 1, rest: [2, 3, 4, 5]))
+}
+
+// --- head ---
+
+pub fn head_single_test() -> Nil {
+  assert non_empty_list.single(1) |> non_empty_list.head == 1
+}
+
+pub fn head_after_cons_test() -> Nil {
+  assert non_empty_list.single(2)
+    |> non_empty_list.cons(head: 1, tail: _)
+    |> non_empty_list.head
+    == 1
+}
+
+pub fn head_multi_test() -> Nil {
+  assert nel.make(first: "a", rest: ["b", "c"]) |> non_empty_list.head == "a"
+}
+
+// --- tail ---
+
+pub fn tail_single_test() -> Nil {
+  assert non_empty_list.single(1) |> non_empty_list.tail == []
+}
+
+pub fn tail_multi_test() -> Nil {
+  assert nel.make(first: 1, rest: [2, 3]) |> non_empty_list.tail == [2, 3]
+}
+
+// --- length ---
+
+pub fn length_single_test() -> Nil {
+  assert non_empty_list.single(1) |> non_empty_list.length == 1
+}
+
+pub fn length_multi_test() -> Nil {
+  assert nel.make(first: 1, rest: [2, 3, 4]) |> non_empty_list.length == 4
+}
+
+// --- fold ---
+
+pub fn fold_sum_test() -> Nil {
+  assert nel.make(first: 1, rest: [2, 3, 4])
+    |> non_empty_list.fold(from: 0, with: fn(acc, item) { acc + item })
+    == 10
+}
+
+pub fn fold_concat_test() -> Nil {
+  assert nel.make(first: "a", rest: ["b", "c"])
+    |> non_empty_list.fold(from: "", with: fn(acc, item) { acc <> item })
+    == "abc"
+}
+
+pub fn fold_single_test() -> Nil {
+  assert non_empty_list.single(5)
+    |> non_empty_list.fold(from: 10, with: fn(acc, item) { acc + item })
+    == 15
+}
+
+// --- reverse ---
+
+pub fn reverse_single_test() -> Nil {
+  assert non_empty_list.single(1)
+    |> non_empty_list.reverse
+    |> non_empty_list.to_list
+    == [1]
+}
+
+pub fn reverse_multi_test() -> Nil {
+  assert nel.make(first: 1, rest: [2, 3, 4])
+    |> non_empty_list.reverse
+    |> non_empty_list.to_list
+    == [4, 3, 2, 1]
+}
+
+pub fn reverse_idempotent_test() -> Nil {
+  let values = nel.make(first: 1, rest: [2, 3])
+  assert values
+    |> non_empty_list.reverse
+    |> non_empty_list.reverse
+    |> non_empty_list.to_list
+    == [1, 2, 3]
 }

--- a/test/dataprep/validated_collection_test.gleam
+++ b/test/dataprep/validated_collection_test.gleam
@@ -1,3 +1,4 @@
+import dataprep/helpers/nel
 import dataprep/non_empty_list
 import dataprep/rules
 import dataprep/validated.{Invalid, Valid}
@@ -25,7 +26,7 @@ pub fn sequence_accumulates_errors_test() -> Nil {
       Valid(3),
       Invalid(non_empty_list.single("e2")),
     ])
-    == Invalid(non_empty_list.NonEmptyList(first: "e1", rest: ["e2"]))
+    == Invalid(nel.make(first: "e1", rest: ["e2"]))
 }
 
 pub fn sequence_single_invalid_test() -> Nil {
@@ -58,7 +59,7 @@ pub fn traverse_accumulates_errors_test() -> Nil {
   assert validated.traverse(["hello", "", "world", ""], fn(s) {
       rules.not_empty(TooShort)(s)
     })
-    == Invalid(non_empty_list.NonEmptyList(first: TooShort, rest: [TooShort]))
+    == Invalid(nel.make(first: TooShort, rest: [TooShort]))
 }
 
 pub fn traverse_with_transform_test() -> Nil {
@@ -114,7 +115,7 @@ pub fn each_all_pass_test() -> Nil {
 pub fn each_accumulates_test() -> Nil {
   let check = validator.each(rules.not_empty(TooShort))
   assert check(["a", "", "b", ""])
-    == Invalid(non_empty_list.NonEmptyList(first: TooShort, rest: [TooShort]))
+    == Invalid(nel.make(first: TooShort, rest: [TooShort]))
 }
 
 pub fn each_empty_list_test() -> Nil {

--- a/test/dataprep/validated_test.gleam
+++ b/test/dataprep/validated_test.gleam
@@ -1,4 +1,5 @@
-import dataprep/non_empty_list.{NonEmptyList}
+import dataprep/helpers/nel
+import dataprep/non_empty_list
 import dataprep/validated.{Invalid, Valid}
 import gleam/int
 
@@ -6,7 +7,7 @@ import gleam/int
 
 pub fn fail_returns_invalid_with_single_error_test() -> Nil {
   let result: validated.Validated(String, String) = validated.fail("oops")
-  assert result == Invalid(NonEmptyList(first: "oops", rest: []))
+  assert result == Invalid(nel.make(first: "oops", rest: []))
 }
 
 pub fn fail_is_equivalent_to_manual_construction_test() -> Nil {
@@ -21,7 +22,7 @@ pub fn map_valid_test() -> Nil {
 
 pub fn map_invalid_test() -> Nil {
   assert Invalid(non_empty_list.single("err")) |> validated.map(fn(x) { x * 3 })
-    == Invalid(NonEmptyList(first: "err", rest: []))
+    == Invalid(nel.make(first: "err", rest: []))
 }
 
 pub fn map_type_change_test() -> Nil {
@@ -38,13 +39,13 @@ pub fn map_error_valid_test() -> Nil {
 pub fn map_error_invalid_test() -> Nil {
   assert Invalid(non_empty_list.single("bad"))
     |> validated.map_error(fn(e) { "wrapped: " <> e })
-    == Invalid(NonEmptyList(first: "wrapped: bad", rest: []))
+    == Invalid(nel.make(first: "wrapped: bad", rest: []))
 }
 
 pub fn map_error_multiple_errors_test() -> Nil {
-  assert Invalid(NonEmptyList(first: "a", rest: ["b"]))
+  assert Invalid(nel.make(first: "a", rest: ["b"]))
     |> validated.map_error(fn(e) { "x:" <> e })
-    == Invalid(NonEmptyList(first: "x:a", rest: ["x:b"]))
+    == Invalid(nel.make(first: "x:a", rest: ["x:b"]))
 }
 
 // --- and_then ---
@@ -68,7 +69,7 @@ pub fn and_then_valid_to_invalid_test() -> Nil {
         False -> Invalid(non_empty_list.single("too small"))
       }
     })
-    == Invalid(NonEmptyList(first: "too small", rest: []))
+    == Invalid(nel.make(first: "too small", rest: []))
 }
 
 pub fn and_then_short_circuits_test() -> Nil {
@@ -77,7 +78,7 @@ pub fn and_then_short_circuits_test() -> Nil {
       // nolint: avoid_panic -- verifies and_then short-circuits on Invalid
       panic as "and_then must not call continuation on Invalid"
     })
-    == Invalid(NonEmptyList(first: "first", rest: []))
+    == Invalid(nel.make(first: "first", rest: []))
 }
 
 pub fn and_then_type_change_test() -> Nil {
@@ -118,7 +119,7 @@ pub fn and_then_does_not_accumulate_test() -> Nil {
       // nolint: avoid_panic -- verifies later and_then stages are skipped
       panic as "should not be called after first and_then fails"
     })
-    == Invalid(NonEmptyList(first: "parse failed", rest: []))
+    == Invalid(nel.make(first: "parse failed", rest: []))
 }
 
 // --- from_result / to_result ---
@@ -129,7 +130,7 @@ pub fn from_result_ok_test() -> Nil {
 
 pub fn from_result_error_test() -> Nil {
   assert validated.from_result(Error("err"))
-    == Invalid(NonEmptyList(first: "err", rest: []))
+    == Invalid(nel.make(first: "err", rest: []))
 }
 
 pub fn to_result_valid_test() -> Nil {
@@ -137,7 +138,7 @@ pub fn to_result_valid_test() -> Nil {
 }
 
 pub fn to_result_invalid_test() -> Nil {
-  assert validated.to_result(Invalid(NonEmptyList(first: "a", rest: ["b"])))
+  assert validated.to_result(Invalid(nel.make(first: "a", rest: ["b"])))
     == Error(["a", "b"])
 }
 
@@ -162,7 +163,7 @@ pub fn map2_accumulates_errors_test() -> Nil {
       Invalid(non_empty_list.single("e1")),
       Invalid(non_empty_list.single("e2")),
     )
-    == Invalid(NonEmptyList(first: "e1", rest: ["e2"]))
+    == Invalid(nel.make(first: "e1", rest: ["e2"]))
 }
 
 pub fn map2_first_invalid_test() -> Nil {
@@ -171,7 +172,7 @@ pub fn map2_first_invalid_test() -> Nil {
       Invalid(non_empty_list.single("e1")),
       Valid(2),
     )
-    == Invalid(NonEmptyList(first: "e1", rest: []))
+    == Invalid(nel.make(first: "e1", rest: []))
 }
 
 pub fn map2_second_invalid_test() -> Nil {
@@ -180,16 +181,16 @@ pub fn map2_second_invalid_test() -> Nil {
       Valid(1),
       Invalid(non_empty_list.single("e2")),
     )
-    == Invalid(NonEmptyList(first: "e2", rest: []))
+    == Invalid(nel.make(first: "e2", rest: []))
 }
 
 pub fn map2_multiple_errors_per_branch_test() -> Nil {
   assert validated.map2(
       fn(a, b) { a + b },
-      Invalid(NonEmptyList(first: "e1a", rest: ["e1b"])),
+      Invalid(nel.make(first: "e1a", rest: ["e1b"])),
       Invalid(non_empty_list.single("e2")),
     )
-    == Invalid(NonEmptyList(first: "e1a", rest: ["e1b", "e2"]))
+    == Invalid(nel.make(first: "e1a", rest: ["e1b", "e2"]))
 }
 
 // --- map3 ---
@@ -210,7 +211,7 @@ pub fn map3_accumulates_errors_test() -> Nil {
       Valid(2),
       Invalid(non_empty_list.single("e3")),
     )
-    == Invalid(NonEmptyList(first: "e1", rest: ["e3"]))
+    == Invalid(nel.make(first: "e1", rest: ["e3"]))
 }
 
 pub fn map3_all_invalid_test() -> Nil {
@@ -220,7 +221,7 @@ pub fn map3_all_invalid_test() -> Nil {
       Invalid(non_empty_list.single("e2")),
       Invalid(non_empty_list.single("e3")),
     )
-    == Invalid(NonEmptyList(first: "e1", rest: ["e2", "e3"]))
+    == Invalid(nel.make(first: "e1", rest: ["e2", "e3"]))
 }
 
 pub fn map3_one_invalid_test() -> Nil {
@@ -230,7 +231,7 @@ pub fn map3_one_invalid_test() -> Nil {
       Invalid(non_empty_list.single("e2")),
       Valid(3),
     )
-    == Invalid(NonEmptyList(first: "e2", rest: []))
+    == Invalid(nel.make(first: "e2", rest: []))
 }
 
 // --- map4 ---
@@ -252,7 +253,7 @@ pub fn map4_accumulates_errors_test() -> Nil {
       Invalid(non_empty_list.single("e3")),
       Invalid(non_empty_list.single("e4")),
     )
-    == Invalid(NonEmptyList(first: "e1", rest: ["e2", "e3", "e4"]))
+    == Invalid(nel.make(first: "e1", rest: ["e2", "e3", "e4"]))
 }
 
 pub fn map4_partial_invalid_test() -> Nil {
@@ -263,7 +264,7 @@ pub fn map4_partial_invalid_test() -> Nil {
       Valid(3),
       Invalid(non_empty_list.single("e4")),
     )
-    == Invalid(NonEmptyList(first: "e2", rest: ["e4"]))
+    == Invalid(nel.make(first: "e2", rest: ["e4"]))
 }
 
 // --- map5 ---
@@ -286,7 +287,7 @@ pub fn map5_accumulates_errors_test() -> Nil {
       Valid(4),
       Invalid(non_empty_list.single("e5")),
     )
-    == Invalid(NonEmptyList(first: "e1", rest: ["e3", "e5"]))
+    == Invalid(nel.make(first: "e1", rest: ["e3", "e5"]))
 }
 
 pub fn map5_all_invalid_test() -> Nil {
@@ -298,7 +299,7 @@ pub fn map5_all_invalid_test() -> Nil {
       Invalid(non_empty_list.single("e4")),
       Invalid(non_empty_list.single("e5")),
     )
-    == Invalid(NonEmptyList(first: "e1", rest: ["e2", "e3", "e4", "e5"]))
+    == Invalid(nel.make(first: "e1", rest: ["e2", "e3", "e4", "e5"]))
 }
 
 pub fn map5_single_invalid_test() -> Nil {
@@ -310,7 +311,7 @@ pub fn map5_single_invalid_test() -> Nil {
       Invalid(non_empty_list.single("e4")),
       Valid(5),
     )
-    == Invalid(NonEmptyList(first: "e4", rest: []))
+    == Invalid(nel.make(first: "e4", rest: []))
 }
 
 // --- error order preservation across mapN ---
@@ -318,10 +319,10 @@ pub fn map5_single_invalid_test() -> Nil {
 pub fn map2_error_order_test() -> Nil {
   assert validated.map2(
       fn(a, b) { #(a, b) },
-      Invalid(NonEmptyList(first: "first", rest: ["second"])),
+      Invalid(nel.make(first: "first", rest: ["second"])),
       Invalid(non_empty_list.single("third")),
     )
-    == Invalid(NonEmptyList(first: "first", rest: ["second", "third"]))
+    == Invalid(nel.make(first: "first", rest: ["second", "third"]))
 }
 
 pub fn map3_error_order_test() -> Nil {
@@ -331,5 +332,5 @@ pub fn map3_error_order_test() -> Nil {
       Invalid(non_empty_list.single("b")),
       Invalid(non_empty_list.single("c")),
     )
-    == Invalid(NonEmptyList(first: "a", rest: ["b", "c"]))
+    == Invalid(nel.make(first: "a", rest: ["b", "c"]))
 }

--- a/test/dataprep/validator_test.gleam
+++ b/test/dataprep/validator_test.gleam
@@ -1,3 +1,4 @@
+import dataprep/helpers/nel
 import dataprep/non_empty_list
 import dataprep/validated.{Invalid, Valid}
 import dataprep/validator
@@ -90,7 +91,7 @@ pub fn both_accumulates_errors_test() -> Nil {
   let v2 = validator.predicate(fn(_: String) { False }, TooLong)
   let validator_under_test = validator.both(first: v1, second: v2)
   assert validator_under_test("x")
-    == Invalid(non_empty_list.NonEmptyList(first: TooShort, rest: [TooLong]))
+    == Invalid(nel.make(first: TooShort, rest: [TooLong]))
 }
 
 pub fn both_first_fails_only_test() -> Nil {
@@ -135,9 +136,7 @@ pub fn both_chained_three_test() -> Nil {
       second: validator.predicate(fn(_) { False }, TooLong),
     )
   assert validator_under_test("x")
-    == Invalid(
-      non_empty_list.NonEmptyList(first: IsEmpty, rest: [TooShort, TooLong]),
-    )
+    == Invalid(nel.make(first: IsEmpty, rest: [TooShort, TooLong]))
 }
 
 // --- all ---
@@ -167,7 +166,7 @@ pub fn all_accumulates_test() -> Nil {
       validator.predicate(fn(_: String) { False }, TooLong),
     ])
   assert validator_under_test("x")
-    == Invalid(non_empty_list.NonEmptyList(first: TooShort, rest: [TooLong]))
+    == Invalid(nel.make(first: TooShort, rest: [TooLong]))
 }
 
 pub fn all_all_fail_test() -> Nil {
@@ -178,9 +177,7 @@ pub fn all_all_fail_test() -> Nil {
       validator.predicate(fn(_: String) { False }, TooLong),
     ])
   assert validator_under_test("x")
-    == Invalid(
-      non_empty_list.NonEmptyList(first: IsEmpty, rest: [TooShort, TooLong]),
-    )
+    == Invalid(nel.make(first: IsEmpty, rest: [TooShort, TooLong]))
 }
 
 pub fn all_all_pass_test() -> Nil {
@@ -222,7 +219,7 @@ pub fn alt_both_fail_accumulates_test() -> Nil {
       second: validator.predicate(fn(_) { False }, NotSlug),
     )
   assert validator_under_test("test")
-    == Invalid(non_empty_list.NonEmptyList(first: NotUuid, rest: [NotSlug]))
+    == Invalid(nel.make(first: NotUuid, rest: [NotSlug]))
 }
 
 pub fn alt_chained_three_first_wins_test() -> Nil {
@@ -251,9 +248,7 @@ pub fn alt_chained_three_all_fail_test() -> Nil {
       second: validator.predicate(fn(_) { False }, TooLong),
     )
   assert validator_under_test("x")
-    == Invalid(
-      non_empty_list.NonEmptyList(first: IsEmpty, rest: [TooShort, TooLong]),
-    )
+    == Invalid(nel.make(first: IsEmpty, rest: [TooShort, TooLong]))
 }
 
 // --- guard ---
@@ -348,7 +343,7 @@ pub fn map_error_multiple_errors_test() -> Nil {
     |> validator.map_error(fn(e) { FieldError("field", e) })
   assert validator_under_test("x")
     == Invalid(
-      non_empty_list.NonEmptyList(first: FieldError("field", TooShort), rest: [
+      nel.make(first: FieldError("field", TooShort), rest: [
         FieldError("field", TooLong),
       ]),
     )
@@ -381,7 +376,7 @@ pub fn label_multiple_errors_test() -> Nil {
     |> validator.label("email", FieldError)
   assert validator_under_test("x")
     == Invalid(
-      non_empty_list.NonEmptyList(first: FieldError("email", IsEmpty), rest: [
+      nel.make(first: FieldError("email", IsEmpty), rest: [
         FieldError("email", TooShort),
       ]),
     )

--- a/test/dataprep_test.gleam
+++ b/test/dataprep_test.gleam
@@ -25,7 +25,6 @@ pub fn main() -> Nil {
   let assert "ok" = prep_alias("ok")
   let assert validated.Valid("ok") = validator_alias("ok")
   let assert validated.Valid("ok") = validated_alias
-  let assert non_empty_list.NonEmptyList(first: "ok", rest: []) =
-    non_empty_list_alias
+  let assert ["ok"] = non_empty_list.to_list(non_empty_list_alias)
   gleeunit.main()
 }


### PR DESCRIPTION
## Summary

Make `NonEmptyList(a)` `pub opaque` so its representation can evolve
without a breaking release, and add the five missing accessors so
callers no longer need pattern matching. Keeps `Validated(a, e)`
transparent and documents that as intentional in a module-level
docstring. Closes #26.

## Changes

- `src/dataprep/non_empty_list.gleam` — type is now `pub opaque type
  NonEmptyList(a)`; new accessors `head`, `tail`, `length`, `fold`,
  `reverse`. `length` and `fold` are routed through `to_list` to keep
  bodies single-line and uniform; `reverse` is implemented via
  `list.fold` over `rest` with `cons` (no panic, no unwrap).
- `src/dataprep/validated.gleam` — added module-level docstring
  stating that pattern matching on `Valid(_)` / `Invalid(_)` is the
  supported call shape and the constructors are part of the stable
  API.
- `test/dataprep/helpers/nel.gleam` — new test helper `nel.make` that
  builds a `NonEmptyList` from `first` + `rest List`. Used to
  mechanically replace direct constructor calls in tests.
- `test/dataprep/non_empty_list_test.gleam` — migrated 22 sites and
  added 11 tests covering the new accessors (single, multi, edge
  cases including `reverse(reverse(x)) == x`).
- `test/dataprep/validated_test.gleam`,
  `test/dataprep/validator_test.gleam`,
  `test/dataprep/validated_collection_test.gleam`,
  `test/dataprep_test.gleam` — migrated 38 remaining sites; the
  `let assert NonEmptyList(...)` destructure in `dataprep_test.gleam`
  is replaced with `let assert ["ok"] = non_empty_list.to_list(...)`.
- `CHANGELOG.md` — `[Unreleased]` documents the BREAKING change with
  the migration path and the new accessors / docstring.

## Design Decisions

- **Opaque NonEmptyList vs. transparent Validated**: `NonEmptyList` is
  a data carrier whose representation is incidental, so hiding the
  constructor avoids future major bumps. `Validated` is the opposite:
  pattern matching on `Valid` / `Invalid` is the natural consume
  shape, so the constructors stay part of the API.
- **`reverse` without panic**: implemented via `list.fold(over: rest,
  from: single(first), with: cons)`. Walks `rest` once, builds the
  reversed NEL by repeated `cons`, no impossible-empty branch, no
  `nolint: avoid_panic` required.
- **`nel.make` helper instead of changing public API**: the project
  convention (per `CLAUDE.md`) is to keep the public surface small.
  Adding a public `from_parts(first:, rest:)` would have re-exposed
  the very thing we're hiding. A test-only helper that goes through
  `from_list` (with a `nolint: assert_ok_pattern` — same pattern
  already used in `prep.collapse_space` and `rules_new_test`) keeps
  the migration mechanical without expanding the API.

## Limitations

- This is a BREAKING change for any external caller that pattern-matched
  or constructed `NonEmptyList(first:, rest:)` directly. The CHANGELOG
  entry documents the migration path explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * `NonEmptyList` is now an opaque type; direct constructor calls and pattern matching are no longer supported.

* **New Features**
  * Five new accessor functions added: `head`, `tail`, `length`, `fold`, and `reverse` for working with non-empty lists without direct pattern matching.

* **Documentation**
  * Clarified usage patterns for `Validated` type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->