### PR TITLE
feat: support JavaScript target for client-side validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,18 @@ jobs:
           gleam-version: "1.15"
       - run: just deps
       - run: just test
+
+  test-javascript:
+    name: Test (JavaScript)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27"
+          gleam-version: "1.15"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: gleam deps download
+      - run: gleam test --target javascript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- JavaScript target support. The `target = "erlang"` constraint has
+  been dropped from `gleam.toml` so the package compiles for both
+  Erlang and JavaScript. Enables sharing the same `Validator(a, e)`
+  between Lustre client-side form validation and a server-side
+  validator (e.g. wisp). The package contains zero FFI and zero
+  target-specific code, so behavior is identical on both runtimes.
+  CI now runs the test suite on both targets. (#25)
+
 ### Changed
 
 - **non_empty_list (BREAKING)**: `NonEmptyList(a)` is now `pub opaque`.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,16 @@ dataprep is a combinator toolkit, not a rule catalog.
 ## Requirements
 
 - Gleam 1.15 or later
-- Erlang/OTP 27 or later
+- Erlang/OTP 27 or later (when targeting Erlang)
+- Node.js 18 or later (when targeting JavaScript)
+
+## Supported targets
+
+- Erlang (BEAM) — for server-side use (e.g. wisp, mist)
+- JavaScript — for client-side use (e.g. Lustre form validation in the
+  browser). The package contains zero FFI and zero target-specific code,
+  so the same `Validator(a, e)` can be shared between client and server
+  code.
 
 ## Install
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,6 +1,5 @@
 name = "dataprep"
 version = "0.6.0"
-target = "erlang"
 description = "Composable, type-driven preprocessing and validation combinator library"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "dataprep" }


### PR DESCRIPTION
## Summary

Drop the `target = \"erlang\"` constraint from `gleam.toml` so the
package compiles for both Erlang and JavaScript. Enables sharing the
same `Validator(a, e)` between Lustre client-side form validation
and a server-side validator (e.g. wisp). Closes #25.

## Changes

- `gleam.toml` — remove `target = \"erlang\"`.
- `.github/workflows/ci.yml` — add `test-javascript` job that runs
  `gleam test --target javascript` on Node 22.
- `README.md` — add a \"Supported targets\" section and update the
  Requirements list to mention Node.js when targeting JavaScript.
- `CHANGELOG.md` — `[Unreleased]` documents the new target support.

## Design Decisions

- **No FFI / no target guards needed**: a quick `git grep '@target\|@external'` on `src/` returned zero hits before the change, so
  `gleam test --target javascript` was expected to pass on the first
  run. Verified locally — all 260 tests pass on both Erlang and
  JavaScript with no source changes.
- **Separate CI job rather than matrix**: the existing Erlang test
  job uses just/erlef-setup-beam; the JavaScript job needs Node, no
  just runner, and a different invocation. A separate job is clearer
  than parameterising the existing one and keeps failure attribution
  obvious.
- **Public API unchanged**: this is a packaging/CI change only. No
  module signatures, no type changes, no migration burden for
  existing Erlang callers.

## Limitations

- The release workflow (`release.yml`) is unchanged. Hex publishes a
  single package that supports both targets, which is the standard
  Gleam behavior, so no release-side changes are required.