### PR TITLE
chore(release): prepare v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-04-28
+
 ### Added
 
 - JavaScript target support. The `target = "erlang"` constraint has

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "dataprep"
-version = "0.6.0"
+version = "0.7.0"
 description = "Composable, type-driven preprocessing and validation combinator library"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "dataprep" }


### PR DESCRIPTION
### Added

- JavaScript target support. The `target = "erlang"` constraint has
  been dropped from `gleam.toml` so the package compiles for both
  Erlang and JavaScript. Enables sharing the same `Validator(a, e)`
  between Lustre client-side form validation and a server-side
  validator (e.g. wisp). The package contains zero FFI and zero
  target-specific code, so behavior is identical on both runtimes.
  CI now runs the test suite on both targets. (#25)
- `non_empty_list.head`, `non_empty_list.tail`, `non_empty_list.length`,
  `non_empty_list.fold`, and `non_empty_list.reverse` accessors so
  callers can observe a `NonEmptyList` without pattern matching.
  `head` is total, `tail` returns a plain `List(a)` (possibly empty),
  `length` is always `>= 1`, `fold` mirrors `gleam/list.fold` with
  `from:` / `with:` labels, and `reverse` returns a `NonEmptyList(a)`.
  (#26)
- Module-level docstring on `dataprep/validated` clarifying that
  `Validated(a, e)` is intentionally a transparent sum type and that
  pattern matching on `Valid` / `Invalid` is the supported call
  shape. (#26)

### Changed

- **non_empty_list (BREAKING)**: `NonEmptyList(a)` is now `pub opaque`.
  Direct constructor calls like `NonEmptyList(first: x, rest: [...])`
  and pattern matches on the `NonEmptyList` constructor no longer
  compile. Construct via `non_empty_list.single`,
  `non_empty_list.cons`, or `non_empty_list.from_list`; observe via
  `non_empty_list.head`, `non_empty_list.tail`,
  `non_empty_list.to_list`, or `non_empty_list.fold`. Hiding the
  representation lets the internal layout evolve without a future
  breaking change. (#26)
