### PR TITLE
refactor(rules): move gleam/order import to top of file

### DIFF
--- a/src/dataprep/rules.gleam
+++ b/src/dataprep/rules.gleam
@@ -1,6 +1,7 @@
 import dataprep/validator.{type Validator}
 import gleam/float
 import gleam/list
+import gleam/order
 import gleam/regexp.{Match}
 import gleam/string
 
@@ -241,5 +242,3 @@ pub fn one_of(allowed allowed: List(a), error error: e) -> Validator(a, e) {
 pub fn equals(expected expected: a, error error: e) -> Validator(a, e) {
   validator.predicate(fn(a) { a == expected }, error)
 }
-
-import gleam/order


### PR DESCRIPTION
## Summary

Move `import gleam/order` from the bottom of `src/dataprep/rules.gleam` to the top of the file with the other imports, matching the convention used by every other source file in the package.

## Changes

- `src/dataprep/rules.gleam`: hoist `import gleam/order` from line 245 (after every function definition) to the top imports block

## Design Decisions

The trailing import position was accepted by the Gleam compiler but inconsistent with the rest of the codebase — readers visually scanning for dependencies would miss it. Moving it to the top is a pure cosmetic change with no behavioural impact; `gleam build --warnings-as-errors`, `glinter`, and `gleam test` all still pass.

Closes #30


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor code cleanup and organization improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->