### PR TITLE
ci(javascript): test min supported Node version (#36)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,12 @@ jobs:
       - run: just test
 
   test-javascript:
-    name: Test (JavaScript)
+    name: Test (JavaScript, Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["18", "22"]
     steps:
       - uses: actions/checkout@v6
       - uses: erlef/setup-beam@v1
@@ -69,6 +73,6 @@ jobs:
           gleam-version: "1.15"
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: ${{ matrix.node-version }}
       - run: gleam deps download
       - run: gleam test --target javascript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **ci(javascript)**: The `Test (JavaScript)` workflow now runs against
+  Node 18 in addition to Node 22, matching the documented minimum
+  supported Node version in the README. Support-floor regressions are
+  now visible in CI instead of relying on ad hoc user reports. (#36)
+
 ## [0.7.0] - 2026-04-28
 
 ### Added


### PR DESCRIPTION
## Summary

Expand the JavaScript CI lane so it runs against the support floor declared in the README.

## Changes

- `.github/workflows/ci.yml` — convert the `test-javascript` job into a `node-version` matrix over `["18", "22"]`. `fail-fast: false` so a regression on either lane stays visible.
- `CHANGELOG.md` — note the new Node 18 lane under `[Unreleased]`.

## Design Decisions

- Kept Node 22 as part of the matrix instead of replacing it, so the upper bound stays exercised.
- Used a matrix instead of two duplicated jobs to avoid drift between the lanes.
- Did not touch the README support statement — it already names Node 18 as the floor; this PR is what makes that statement load-bearing.

Closes #36
