### PR TITLE
chore(release): prepare v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-04-30
+
 ### Added
 
 - **rules**: `matches_string_checked` and `matches_fully_string_checked`

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "dataprep"
-version = "0.7.0"
+version = "0.8.0"
 description = "Composable, type-driven preprocessing and validation combinator library"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "dataprep" }


### PR DESCRIPTION
### Added

- **rules**: `matches_string_checked` and `matches_fully_string_checked`
  return `Result(Validator(String, e), RegexRuleError)` instead of
  panicking on a malformed pattern. Use these when the pattern comes
  from config or admin-supplied input — the panicking
  `matches_string` / `matches_fully_string` helpers stay available
  for hard-coded literal patterns. The `RegexRuleError.InvalidPattern`
  variant exposes both `reason` and `byte_index` so callers can
  surface meaningful diagnostics without depending on `gleam/regexp`
  directly. (#35)

### Changed

- **ci(javascript)**: The `Test (JavaScript)` workflow now runs against
  Node 18 in addition to Node 22, matching the documented minimum
  supported Node version in the README. Support-floor regressions are
  now visible in CI instead of relying on ad hoc user reports. (#36)
