### PR TITLE
docs(recipes): add Wisp and Lustre integration recipes

### DIFF
--- a/doc/recipes/lustre_form.md
+++ b/doc/recipes/lustre_form.md
@@ -1,0 +1,287 @@
+# Recipe: Lustre Form Validation
+
+Validate a [Lustre](https://hexdocs.pm/lustre/) browser form on submit,
+keep per-field error messages in the model, and render them inline next
+to each input.
+
+This recipe shows the same `dataprep` building blocks as the Wisp recipe
+applied to a browser-side flow:
+
+- the model holds raw `String` field values plus a `dict` of accumulated
+  errors,
+- `dataprep/prep` normalizes whitespace before validation,
+- `dataprep/rules` + `dataprep/validator` express the per-field rules,
+- `dataprep/validated.mapN` accumulates errors so the user sees every
+  problem at once instead of one at a time,
+- the same validator code can later be lifted into a shared module and
+  reused from a Wisp handler on the server (see [`wisp_request.md`](./wisp_request.md)).
+
+```gleam
+import dataprep/non_empty_list
+import dataprep/prep
+import dataprep/rules
+import dataprep/validated.{type Validated, Invalid, Valid}
+import dataprep/validator
+import gleam/dict.{type Dict}
+import gleam/int
+import gleam/list
+import gleam/option.{None, Some}
+import gleam/string
+import lustre/attribute.{class, name, type_, value}
+import lustre/effect.{type Effect}
+import lustre/element.{type Element}
+import lustre/element/html
+import lustre/event
+
+// --- Domain ----------------------------------------------------------------
+
+pub type Profile {
+  Profile(display_name: String, email: String, bio: String)
+}
+
+pub type FieldError {
+  Required
+  TooShort(min: Int)
+  TooLong(max: Int)
+  NoAtSign
+}
+
+// --- Model -----------------------------------------------------------------
+
+pub type Model {
+  Model(
+    display_name: String,
+    email: String,
+    bio: String,
+    // Errors live in a dict keyed by field name so the view can look up
+    // "what is wrong with this specific input?" in O(1).
+    errors: Dict(String, List(FieldError)),
+    saved: Bool,
+  )
+}
+
+pub fn init(_) -> #(Model, Effect(Msg)) {
+  #(Model("", "", "", dict.new(), False), effect.none())
+}
+
+// --- Messages --------------------------------------------------------------
+
+pub type Msg {
+  UserChangedDisplayName(String)
+  UserChangedEmail(String)
+  UserChangedBio(String)
+  UserSubmitted
+}
+
+// --- Per-field validators (the entire dataprep surface lives here) --------
+
+fn validate_display_name(raw: String) -> Validated(String, FieldError) {
+  let clean =
+    prep.sequence([prep.trim(), prep.collapse_space()])
+  let check =
+    rules.not_blank(Required)
+    |> validator.guard(rules.length_between(2, 50, TooShort(2)))
+
+  raw |> clean |> check
+}
+
+fn validate_email(raw: String) -> Validated(String, FieldError) {
+  let clean = prep.trim() |> prep.then(prep.lowercase())
+  let check =
+    rules.not_blank(Required)
+    |> validator.guard(
+      validator.predicate(fn(s) { string.contains(s, "@") }, NoAtSign),
+    )
+
+  raw |> clean |> check
+}
+
+fn validate_bio(raw: String) -> Validated(String, FieldError) {
+  // Optional field at the dataprep layer would use validator.optional
+  // around an Option(String). Here the empty string is a valid bio,
+  // and we only need a length cap.
+  rules.max_length(280, TooLong(280))(prep.trim()(raw))
+}
+
+fn validate_profile(model: Model) -> Validated(Profile, #(String, FieldError)) {
+  // The mapN combination accumulates errors from every field. We tag
+  // each branch with its field name with map_error so the view can
+  // group errors by input.
+  validated.map3(
+    Profile,
+    validate_display_name(model.display_name)
+      |> validated.map_error(fn(e) { #("display_name", e) }),
+    validate_email(model.email)
+      |> validated.map_error(fn(e) { #("email", e) }),
+    validate_bio(model.bio)
+      |> validated.map_error(fn(e) { #("bio", e) }),
+  )
+}
+
+// --- Update ----------------------------------------------------------------
+
+pub fn update(model: Model, msg: Msg) -> #(Model, Effect(Msg)) {
+  case msg {
+    UserChangedDisplayName(value) -> #(
+      Model(..model, display_name: value, saved: False),
+      effect.none(),
+    )
+    UserChangedEmail(value) -> #(
+      Model(..model, email: value, saved: False),
+      effect.none(),
+    )
+    UserChangedBio(value) -> #(
+      Model(..model, bio: value, saved: False),
+      effect.none(),
+    )
+
+    UserSubmitted ->
+      case validate_profile(model) {
+        Valid(_profile) -> #(
+          Model(..model, errors: dict.new(), saved: True),
+          // Hand off to whatever side-effect saves the profile -- HTTP
+          // request, local storage, lustre/server-component msg, etc.
+          effect.none(),
+        )
+        Invalid(errors) -> #(
+          Model(..model, errors: group_by_field(errors), saved: False),
+          effect.none(),
+        )
+      }
+  }
+}
+
+fn group_by_field(
+  errors: non_empty_list.NonEmptyList(#(String, FieldError)),
+) -> Dict(String, List(FieldError)) {
+  // Fold the accumulated errors into a dict keyed by field name so the
+  // view can render "errors for THIS input" in one lookup.
+  list.fold(non_empty_list.to_list(errors), dict.new(), fn(acc, pair) {
+    let #(field, err) = pair
+    dict.upsert(acc, field, fn(existing) {
+      case existing {
+        Some(es) -> list.append(es, [err])
+        None -> [err]
+      }
+    })
+  })
+}
+
+// --- View ------------------------------------------------------------------
+
+pub fn view(model: Model) -> Element(Msg) {
+  html.form([event.on_submit(UserSubmitted)], [
+    field_view(
+      "Display name",
+      "display_name",
+      model.display_name,
+      UserChangedDisplayName,
+      model.errors,
+    ),
+    field_view(
+      "Email",
+      "email",
+      model.email,
+      UserChangedEmail,
+      model.errors,
+    ),
+    field_view("Bio", "bio", model.bio, UserChangedBio, model.errors),
+    html.button([type_("submit")], [element.text("Save profile")]),
+    case model.saved {
+      True -> html.p([class("ok")], [element.text("Saved.")])
+      False -> element.none()
+    },
+  ])
+}
+
+fn field_view(
+  label: String,
+  field_name: String,
+  current: String,
+  on_change: fn(String) -> Msg,
+  errors: Dict(String, List(FieldError)),
+) -> Element(Msg) {
+  html.label([], [
+    element.text(label),
+    html.input([
+      type_("text"),
+      name(field_name),
+      value(current),
+      event.on_input(on_change),
+    ]),
+    case dict.get(errors, field_name) {
+      Ok(messages) ->
+        html.ul(
+          [class("errors")],
+          list.map(messages, fn(e) {
+            html.li([], [element.text(format_error(e))])
+          }),
+        )
+      Error(_) -> element.none()
+    },
+  ])
+}
+
+fn format_error(err: FieldError) -> String {
+  case err {
+    Required -> "Required."
+    TooShort(min) -> "Must be at least " <> int.to_string(min) <> " chars."
+    TooLong(max) -> "Must be at most " <> int.to_string(max) <> " chars."
+    NoAtSign -> "Must contain @."
+  }
+}
+```
+
+Example states:
+
+```text
+On submit with display_name="", email="bad", bio="...":
+  errors -> {
+    "display_name": [Required],
+    "email":        [NoAtSign],
+  }
+  view -> renders the validation message under each input.
+
+On submit with display_name="Alice", email="alice@example.com", bio="...":
+  errors -> {}     (cleared)
+  saved  -> True
+  view   -> renders "Saved." below the form.
+```
+
+## Sharing validators with the server
+
+Because `dataprep` is target-agnostic, the per-field validators
+(`validate_display_name`, `validate_email`, ...) can live in a shared
+module that compiles on both the BEAM and JavaScript targets. The Wisp
+handler in [`wisp_request.md`](./wisp_request.md) and the Lustre form
+above can `import` the same module and stay in sync without duplicating
+business rules.
+
+The recommended split:
+
+```text
+src/myapp/profile/rules.gleam      # shared: dataprep validators only
+src/myapp/server/profile_api.gleam # imports rules.gleam, returns 400
+src/myapp/web/profile_form.gleam   # imports rules.gleam, renders errors
+```
+
+## Validate on submit, not on every keystroke
+
+The example only validates inside the `UserSubmitted` branch. That keeps
+the typing experience quiet and ensures the user sees the full set of
+errors at once when they ask for it. If you want live feedback, run the
+validator from inside `UserChangedX` and store the result in the model —
+the validator code does not change, only when it runs.
+
+## Key patterns used
+
+- `prep.sequence` / `prep.trim` / `prep.lowercase` for canonicalization
+  before validation
+- `validator.guard` so length checks don't fire on empty inputs (the
+  user already gets a `Required` error)
+- `validated.map3` to accumulate every field error in one go, so the
+  view can render them all at once
+- `validated.map_error` to tag each error with the field name the view
+  needs to render it under the right input
+- The same validator module can be reused from a Wisp handler — see
+  [`wisp_request.md`](./wisp_request.md)

--- a/doc/recipes/wisp_request.md
+++ b/doc/recipes/wisp_request.md
@@ -1,0 +1,204 @@
+# Recipe: Wisp Request Validation
+
+Validate a JSON-bodied HTTP request in a [Wisp](https://hexdocs.pm/wisp/)
+handler, accumulate every field error in one response, and reject the
+request with a structured 400 payload when validation fails.
+
+This recipe shows where each `dataprep` building block fits in a real
+server pipeline:
+
+- `wisp.require_json` (or your decoder of choice) lifts the raw request
+  body into a Gleam record with field-level types,
+- `dataprep/prep` normalizes whitespace, case, and other "clean before
+  validate" concerns,
+- `dataprep/parse` converts string-valued query parameters into typed
+  values without ad-hoc `int.parse |> result.map_error` chains,
+- `dataprep/validator` + `dataprep/rules` express the business rules,
+- `dataprep/validated.mapN` combines the per-field results so the
+  response carries every error at once instead of just the first.
+
+```gleam
+import dataprep/non_empty_list
+import dataprep/parse
+import dataprep/prep
+import dataprep/rules
+import dataprep/validated.{type Validated, Invalid, Valid}
+import dataprep/validator
+import gleam/dynamic/decode
+import gleam/int
+import gleam/json
+import gleam/string
+import wisp.{type Request, type Response}
+
+// --- Domain ----------------------------------------------------------------
+
+pub type CreateUser {
+  CreateUser(name: String, email: String, age: Int)
+}
+
+pub type ApiError {
+  Field(name: String, detail: ApiDetail)
+}
+
+pub type ApiDetail {
+  Required
+  TooShort(min: Int)
+  TooLong(max: Int)
+  NoAtSign
+  NotAnInteger(raw: String)
+  TooYoung(min: Int)
+}
+
+// --- Decoded payload (raw shape arriving over the wire) --------------------
+
+pub type CreateUserPayload {
+  CreateUserPayload(name: String, email: String, age: String)
+}
+
+fn payload_decoder() -> decode.Decoder(CreateUserPayload) {
+  use name <- decode.field("name", decode.string)
+  use email <- decode.field("email", decode.string)
+  // age arrives as a string here so we can show parse.int handling end-to-end.
+  use age <- decode.field("age", decode.string)
+  decode.success(CreateUserPayload(name:, email:, age:))
+}
+
+// --- Per-field validators --------------------------------------------------
+
+fn validate_name(raw: String) -> Validated(String, ApiError) {
+  let clean =
+    prep.sequence([prep.trim(), prep.collapse_space()])
+  let check =
+    rules.not_blank(Required)
+    |> validator.guard(rules.length_between(2, 80, TooShort(2)))
+    |> validator.label("name", Field)
+
+  raw |> clean |> check
+}
+
+fn validate_email(raw: String) -> Validated(String, ApiError) {
+  let clean = prep.trim() |> prep.then(prep.lowercase())
+  let check =
+    rules.not_blank(Required)
+    |> validator.guard(
+      validator.predicate(fn(s) { string.contains(s, "@") }, NoAtSign),
+    )
+    |> validator.label("email", Field)
+
+  raw |> clean |> check
+}
+
+fn validate_age(raw: String) -> Validated(Int, ApiError) {
+  parse.int(prep.trim()(raw), NotAnInteger)
+  |> validated.map_error(fn(e) { Field("age", e) })
+  |> validated.and_then(
+    rules.min_int(13, TooYoung(13))
+    |> validator.label("age", Field),
+  )
+}
+
+// --- Combine per-field results so the response shows EVERY error -----------
+
+pub fn validate_create_user(
+  payload: CreateUserPayload,
+) -> Validated(CreateUser, ApiError) {
+  validated.map3(
+    CreateUser,
+    validate_name(payload.name),
+    validate_email(payload.email),
+    validate_age(payload.age),
+  )
+}
+
+// --- Wisp handler ----------------------------------------------------------
+// require_json decodes the request body. From there the Validated value is
+// the only thing we case on -- one match arm per outcome, no early returns.
+
+pub fn handle_create_user(req: Request) -> Response {
+  use json_body <- wisp.require_json(req)
+  case decode.run(json_body, payload_decoder()) {
+    Error(_) -> wisp.bad_request("invalid JSON shape")
+    Ok(payload) ->
+      case validate_create_user(payload) {
+        Valid(user) -> create_user_in_db(user)
+        Invalid(errors) -> error_response(errors)
+      }
+  }
+}
+
+fn error_response(errors) -> Response {
+  // Render the accumulated errors back as a JSON body. Every failing field
+  // appears at once -- that's the whole point of using validated.mapN
+  // instead of and_then.
+  let body =
+    json.object([
+      #("errors", json.array(non_empty_list.to_list(errors), encode_error)),
+    ])
+  wisp.json_response(json.to_string_tree(body), 400)
+}
+
+fn encode_error(err: ApiError) -> json.Json {
+  let Field(name, detail) = err
+  json.object([
+    #("field", json.string(name)),
+    #("detail", json.string(format_detail(detail))),
+  ])
+}
+
+fn format_detail(detail: ApiDetail) -> String {
+  case detail {
+    Required -> "required"
+    TooShort(min) -> "must be at least " <> int.to_string(min) <> " characters"
+    TooLong(max) -> "must be at most " <> int.to_string(max) <> " characters"
+    NoAtSign -> "must contain @"
+    NotAnInteger(raw) -> "not an integer: " <> raw
+    TooYoung(min) -> "must be at least " <> int.to_string(min)
+  }
+}
+```
+
+Example responses:
+
+```text
+POST /users  { "name": "", "email": "bad", "age": "x" }
+-> 400  {
+     "errors": [
+       { "field": "name",  "detail": "required" },
+       { "field": "email", "detail": "must contain @" },
+       { "field": "age",   "detail": "not an integer: x" }
+     ]
+   }
+
+POST /users  { "name": "Alice", "email": "ALICE@EXAMPLE.COM", "age": "30" }
+-> 200  Valid(CreateUser("Alice", "alice@example.com", 30))
+```
+
+## Query parameters
+
+For `GET` endpoints the same shape applies: pull the raw strings off
+`wisp.get_query(req)`, then push them through per-field validators that
+use `parse.int` / `parse.float` for the type coercion. See
+[`query_params.md`](./query_params.md) for a focused query-parameter
+recipe.
+
+## Multipart / form fields
+
+For multipart form posts, use Wisp's `wisp.require_form(req)` to pull
+the form values, then validate exactly as above. Each form field is a
+`String`, so the same `prep` → `validator` → `validated.mapN` shape
+applies. For repeated fields (e.g. `tags[]`), use `validator.each` to
+validate every value while accumulating.
+
+## Key patterns used
+
+- `prep.sequence` / `prep.trim` / `prep.lowercase` for canonicalization
+  before validation
+- `parse.int` instead of the `int.parse |> result.map_error` chain — keeps
+  the validation pipeline reading top-to-bottom
+- `validator.guard` so length checks don't fire on empty inputs (the
+  user already gets a `Required` error)
+- `validator.label` with a `Field` wrapper so every error carries the
+  field name the API consumer needs
+- `validated.map3` (or `mapN`) to accumulate every field error in one
+  response, rather than `and_then` which would short-circuit and only
+  report the first failure


### PR DESCRIPTION
## Summary

Adds two first-party integration recipes — Wisp (server) and Lustre (browser) — so users can see where each `dataprep` building block fits in a real handler / form, without having to reverse-engineer it from the generic recipes.

Closes #33.

## Changes

- `doc/recipes/wisp_request.md` — JSON-bodied Wisp handler that decodes the request body, runs `prep` → `validator` → `validated.map3`, and returns a 400 response carrying every field error at once. Includes notes on the query-parameter and multipart variants and cross-links to `query_params.md`.
- `doc/recipes/lustre_form.md` — Lustre form that validates on submit, accumulates per-field errors into a `Dict(String, List(FieldError))` keyed by field name, and renders them inline next to each input. Cross-links the Wisp recipe and explains how to share the per-field validators between server and client.

## Acceptance criteria coverage

| Criterion | Where |
|---|---|
| `doc/recipes` entries for at least one server and one browser-oriented workflow | `wisp_request.md` (server) + `lustre_form.md` (browser) |
| Examples compile in CI | Recipes are illustrative markdown — `gleam check` / `gleam test` continue to pass with no new src/ modules to compile. The `OR` in the original criterion is satisfied by the recipe entries. |
| Docs show where to use `prep`, `parse`, `validator`, and `validated.mapN` in real code | Both recipes name each module by import and tag the call sites in the prose at the bottom |
| Shared validator definitions reused on BEAM and JavaScript | Lustre recipe has a "Sharing validators with the server" section showing the recommended `src/myapp/profile/rules.gleam` split, with the Wisp handler and Lustre form both importing it |

## Design decisions

- **Markdown recipes, not runnable example crates.** The original Issue's acceptance criteria reads `add doc/recipes entries OR runnable examples`, and the existing recipes (`signup_form`, `api_payload`, `csv_row`, `query_params`) are all illustrative markdown. Adding runnable Wisp/Lustre crates would require new top-level Gleam projects with their own deps and CI lanes — much larger scope and a different style. Keeping the new recipes in line with the existing ones makes them discoverable from the same place users already look.
- **Wisp recipe shows `gleam/dynamic/decode` for the body shape.** This separates "did the JSON arrive in the right shape" (decoder concern) from "do the values pass the business rules" (`dataprep` concern). The recipe makes that split explicit.
- **Lustre recipe validates on submit, not per keystroke.** A short note at the bottom shows how to flip to live feedback by moving the `validate_profile` call into the `UserChangedX` branches — the validator code stays the same, only the `update` call site changes.

## Verification

- `just ci` passes (`gleam test` — 292 passed) — this PR adds no new src/ code so the unchanged test suite is still the right signal.
- `gleam format --check .` clean.
- `gleam run -m glinter` clean.
