### PR TITLE
chore(release): prepare v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-05-06
+
 ### Fixed
 
 - **rules**: `matches_fully_string` and `matches_fully_string_checked`

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "dataprep"
-version = "0.10.0"
+version = "0.11.0"
 description = "Composable, type-driven preprocessing and validation combinator library"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "dataprep" }


### PR DESCRIPTION
### Fixed

- **rules**: `matches_fully_string` and `matches_fully_string_checked`
  now correctly accept inputs that match a non-leftmost branch of a
  top-level alternation. The pattern is anchored as `^(?:pattern)$`
  inside the helper before compilation, so e.g. `"a|ab"` against
  `"ab"` is now `Valid` (matching Python `re.fullmatch` semantics)
  instead of being rejected because `regexp.scan` chose the shorter
  `a` alternative. The compiled-regex variant `matches_fully` cannot
  be fixed in place — `Regexp` is opaque and the source pattern is
  unrecoverable — so its docstring now documents the alternation
  caveat and points callers at the `_string` / `_string_checked`
  variants. (#47)
