### PR TITLE
fix(prep)!: collapse_space matches ASCII whitespace only; add collapse_unicode_space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [0.11.0] - 2026-05-06
+### Added
+
+- **prep**: `prep.collapse_unicode_space()` collapses runs of Unicode
+  whitespace (`\s+` under the regex engine's full Unicode rule, so
+  NO-BREAK SPACE, IDEOGRAPHIC SPACE, EN/EM spaces, etc. all match)
+  into a single ASCII space. Reach for this when callers actually
+  want the broader fold; the default `collapse_space` no longer does
+  it. (#50)
+
+### Changed
+
+- **Breaking (prep)**: `prep.collapse_space()` now matches **ASCII
+  whitespace only** (`[ \t\n\r\f\v]`). Previously it used `\s+`,
+  which under the Erlang regex engine matches Unicode whitespace too
+  and silently rewrote NO-BREAK SPACE (U+00A0) and IDEOGRAPHIC SPACE
+  (U+3000) to a regular ASCII space — destructive in CJK contexts
+  where `姓　名` (with U+3000 between names) would become `姓 名`
+  with no warning. The Unicode-aware behaviour is still available as
+  `prep.collapse_unicode_space()` for callers who need it. (#50)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ More examples are available in the [doc/recipes/](https://github.com/nao1215/dat
 
 | Module | Responsibility |
 |--------|---------------|
-| `dataprep/prep` | Infallible transformations: `trim`, `lowercase`, `uppercase`, `collapse_space`, `replace`, `default`. Compose with `then` or `sequence`. |
+| `dataprep/prep` | Infallible transformations: `trim`, `lowercase`, `uppercase`, `collapse_space` (ASCII whitespace only), `collapse_unicode_space` (full Unicode `\s`), `replace`, `default`. Compose with `then` or `sequence`. |
 | `dataprep/validator` | Checks without transformation: `check`, `predicate`, `both`, `all`, `alt`, `guard`, `map_error`, `label`, `each`, `optional`. |
 | `dataprep/validated` | Applicative error accumulation: `map`, `map_error`, `and_then`, `from_result`, `from_result_map`, `to_result`, `map2`..`map5`, `sequence`, `traverse`, `traverse_indexed`. |
 | `dataprep/non_empty_list` | At-least-one guarantee for error lists: `single`, `cons`, `append`, `concat`, `map`, `flat_map`, `to_list`, `from_list`. |

--- a/src/dataprep/prep.gleam
+++ b/src/dataprep/prep.gleam
@@ -40,12 +40,43 @@ pub fn uppercase() -> Prep(String) {
   string.uppercase
 }
 
-/// Collapse consecutive whitespace into a single space.
+/// Collapse consecutive **ASCII** whitespace into a single space.
 ///
-/// Uses `let assert` for the regex compilation. The pattern `\s+` is
-/// a fixed, known-valid regular expression, so compilation cannot fail
+/// Matches the POSIX whitespace class `[ \t\n\r\f\v]` (space, tab,
+/// linefeed, carriage return, form feed, vertical tab). Unicode
+/// whitespace such as NO-BREAK SPACE (U+00A0) and IDEOGRAPHIC SPACE
+/// (U+3000) is **preserved** — for those use `collapse_unicode_space`
+/// (it matches the wider Unicode `\s` set and replaces every run with
+/// a single ASCII space).
+///
+/// This split avoids the silent CJK-destruction footgun of replacing
+/// `姓　名` (with U+3000 between the names) with `姓 名` when the
+/// caller only meant to normalise indentation.
+///
+/// Uses `let assert` for the regex compilation. The pattern is a
+/// fixed, known-valid regular expression, so compilation cannot fail
 /// at runtime. The assert is intentional and safe.
 pub fn collapse_space() -> Prep(String) {
+  // nolint: assert_ok_pattern -- the bracket expression is a fixed, known-valid regex literal
+  let assert Ok(re) = regexp.from_string("[ \\t\\n\\r\\f\\v]+")
+  fn(s) { regexp.replace(each: re, in: s, with: " ") }
+}
+
+/// Collapse consecutive Unicode whitespace into a single ASCII space.
+///
+/// Matches `\s+` under the regex engine's full Unicode rule, so it
+/// recognises NO-BREAK SPACE (U+00A0), IDEOGRAPHIC SPACE (U+3000),
+/// LINE / PARAGRAPH SEPARATOR (U+2028 / U+2029), the various EN/EM
+/// SPACEs (U+2000..U+200A), etc. Each run — even one made entirely of
+/// non-ASCII whitespace — is rewritten to a single ASCII U+0020.
+///
+/// Reach for `collapse_space` instead when the caller wants to keep
+/// CJK / typographic whitespace intact and only fold ASCII runs.
+///
+/// Uses `let assert` for the regex compilation. The pattern `\s+` is
+/// a fixed, known-valid regular expression, so compilation cannot
+/// fail at runtime. The assert is intentional and safe.
+pub fn collapse_unicode_space() -> Prep(String) {
   // nolint: assert_ok_pattern -- "\\s+" is a fixed, known-valid regex literal
   let assert Ok(re) = regexp.from_string("\\s+")
   fn(s) { regexp.replace(each: re, in: s, with: " ") }

--- a/test/dataprep/prep_test.gleam
+++ b/test/dataprep/prep_test.gleam
@@ -84,6 +84,54 @@ pub fn collapse_space_tabs_and_newlines_test() -> Nil {
   assert prep.collapse_space()("\t\na\n\n\tb\t") == " a b "
 }
 
+pub fn collapse_space_preserves_nbsp_test() -> Nil {
+  // NO-BREAK SPACE (U+00A0) is Unicode whitespace but not in the
+  // ASCII whitespace class, so collapse_space leaves it alone.
+  let nbsp = "\u{00A0}"
+  let input = "a" <> nbsp <> nbsp <> "b"
+  assert prep.collapse_space()(input) == input
+}
+
+pub fn collapse_space_preserves_ideographic_space_test() -> Nil {
+  // IDEOGRAPHIC SPACE (U+3000) — full-width Japanese space — must
+  // survive `collapse_space` for CJK callers (姓　名 stays intact).
+  let ideographic = "\u{3000}"
+  let input = "姓" <> ideographic <> ideographic <> "名"
+  assert prep.collapse_space()(input) == input
+}
+
+pub fn collapse_space_collapses_ascii_runs_around_unicode_whitespace_test() -> Nil {
+  // ASCII runs collapse, but the surrounding Unicode whitespace stays.
+  let nbsp = "\u{00A0}"
+  let input = "a   " <> nbsp <> "   b"
+  assert prep.collapse_space()(input) == "a " <> nbsp <> " b"
+}
+
+// --- collapse_unicode_space ---
+
+pub fn collapse_unicode_space_collapses_nbsp_test() -> Nil {
+  // The opt-in Unicode variant DOES fold NO-BREAK SPACE runs into a
+  // single ASCII space.
+  let nbsp = "\u{00A0}"
+  let input = "a" <> nbsp <> nbsp <> "b"
+  assert prep.collapse_unicode_space()(input) == "a b"
+}
+
+pub fn collapse_unicode_space_collapses_ideographic_test() -> Nil {
+  let ideographic = "\u{3000}"
+  let input = "a" <> ideographic <> ideographic <> "b"
+  assert prep.collapse_unicode_space()(input) == "a b"
+}
+
+pub fn collapse_unicode_space_collapses_ascii_runs_test() -> Nil {
+  // Behaves identically to the old `collapse_space` for pure-ASCII input.
+  assert prep.collapse_unicode_space()("a   b\t\tc") == "a b c"
+}
+
+pub fn collapse_unicode_space_empty_test() -> Nil {
+  assert prep.collapse_unicode_space()("") == ""
+}
+
 // --- replace ---
 
 pub fn replace_test() -> Nil {


### PR DESCRIPTION
## Summary

`prep.collapse_space()` previously used `\s+`, which under the Erlang regex engine matches *Unicode* whitespace (NO-BREAK SPACE, IDEOGRAPHIC SPACE, EN/EM spaces, etc.) and silently rewrote each run with a single ASCII U+0020. In CJK contexts that is destructive: `姓　名` (with U+3000 between names) became `姓 名` with no warning. This PR restricts the default to ASCII whitespace only, and exposes the previous behaviour as the opt-in `prep.collapse_unicode_space()`.

## Changes

- `src/dataprep/prep.gleam`:
  - `collapse_space()` now uses the bracket pattern `[ \t\n\r\f\v]+`, so it only collapses POSIX ASCII whitespace. Unicode whitespace is preserved verbatim.
  - `collapse_unicode_space()` (new) keeps the old `\s+` behaviour: matches the regex engine's full Unicode `\s` and rewrites each run with a single ASCII space.
  - Both docstrings cross-reference each other so users pick the right tool at the call site.
- `test/dataprep/prep_test.gleam` — eight new regression tests:
  - `collapse_space_preserves_nbsp_test`, `collapse_space_preserves_ideographic_space_test`, `collapse_space_collapses_ascii_runs_around_unicode_whitespace_test` pin the new ASCII-only behaviour with the two CJK-relevant codepoints (NBSP, U+3000).
  - `collapse_unicode_space_collapses_nbsp_test`, `_collapses_ideographic_test`, `_collapses_ascii_runs_test`, `_empty_test` pin the opt-in Unicode variant.
  - The existing `collapse_space_test` suite stays green: ASCII-only inputs (` `, `\t`, `\n`) collapse exactly as before.
- `README.md` — Modules table updated to list both helpers and the ASCII / Unicode distinction.
- `CHANGELOG.md` — `[Unreleased]` documents the breaking default change and the additive Unicode variant.

## Design Decisions

- **Default to ASCII, opt-in to Unicode.** Issue #50 listed three options. Going with (2) — ASCII default + Unicode opt-in — matches what callers reading the docstring \"collapse consecutive whitespace\" most plausibly expect (POSIX `\s`), and removes the silent CJK-destruction footgun. Option (3) (\"preserve the original whitespace character\") was rejected because it would surprise callers who read \"collapse to a single space\" as a normalisation primitive — they want the output to be *one* deterministic character.
- **Bracket expression vs explicit class.** The new `[ \\t\\n\\r\\f\\v]+` is the verbatim POSIX whitespace class. It is explicit, matches the docs, and avoids relying on the regex engine's locale-aware `\s` interpretation.
- **No `collapse_ascii_space` alias.** The default is ASCII now, so a separate `_ascii_` name would be redundant. Users opting into the wider rule reach for `collapse_unicode_space` once.

## Limitations

- The change is **breaking** for callers depending on the old Unicode-folding behaviour. The CHANGELOG entry directs them at the new `collapse_unicode_space()` for a one-line migration. No fancier deprecation shim is offered because the breaking-ness is the whole point of the fix — callers should consciously decide which whitespace class their pipeline wants.
- `collapse_unicode_space` still rewrites Unicode whitespace runs to a single ASCII U+0020, not the first character of the run. If a caller wants the most-preserving variant (option 3 in the issue), it can be a follow-up.

Closes #50