### PR TITLE
feat(prep): add default_when_blank and pin trim+default composition in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **prep**: `prep.default_when_blank(fallback)` falls back when the
+  input is the literal empty string **or** whitespace-only (per
+  `string.trim`). The existing `prep.default(fallback)` keeps its
+  literal-empty-only contract; pick the right tool side-by-side via
+  the new \"`default` vs `default_when_blank`\" README section. The
+  documented `prep.trim() |> prep.then(prep.default(...))` composition
+  is now exercised by `gleam test` so the example cannot rot. (#52)
 - **prep**: `prep.collapse_unicode_space()` collapses runs of Unicode
   whitespace (`\s+` under the regex engine's full Unicode rule, so
   NO-BREAK SPACE, IDEOGRAPHIC SPACE, EN/EM spaces, etc. all match)

--- a/README.md
+++ b/README.md
@@ -288,13 +288,38 @@ pub fn validate_with(
 // validate_tag("BAD!") -> Invalid([BadFormat])
 ```
 
+### `default` vs `default_when_blank`
+
+`prep.default(fallback)` only fires on the literal empty string `""`. Whitespace-only inputs (`" "`, `"\t"`, `"\r\n"`) pass through unchanged. Use `prep.default_when_blank(fallback)` when \"blank\" should also include whitespace-only.
+
+```gleam
+import dataprep/prep
+
+let strict = prep.default("N/A")
+strict("")          // "N/A"
+strict(" ")         // " "          ← passed through
+strict("\t")        // "\t"         ← passed through
+strict("hi")        // "hi"
+
+let lenient = prep.default_when_blank("N/A")
+lenient("")         // "N/A"
+lenient(" ")        // "N/A"        ← whitespace-only treated as blank
+lenient("\t\n")     // "N/A"
+lenient("  hi  ")   // "  hi  "     ← original input preserved on non-blank
+
+// Want the trimmed form on the non-blank path? Compose explicitly:
+let normalised = prep.trim() |> prep.then(first: _, next: prep.default("N/A"))
+normalised("  hi  ") // "hi"
+normalised("   ")    // "N/A"
+```
+
 More examples are available in the [doc/recipes/](https://github.com/nao1215/dataprep/tree/main/doc/recipes) directory of the repository.
 
 ## Modules
 
 | Module | Responsibility |
 |--------|---------------|
-| `dataprep/prep` | Infallible transformations: `trim`, `lowercase`, `uppercase`, `collapse_space` (ASCII whitespace only), `collapse_unicode_space` (full Unicode `\s`), `replace`, `default`. Compose with `then` or `sequence`. |
+| `dataprep/prep` | Infallible transformations: `trim`, `lowercase`, `uppercase`, `collapse_space` (ASCII whitespace only), `collapse_unicode_space` (full Unicode `\s`), `replace`, `default`, `default_when_blank`. Compose with `then` or `sequence`. |
 | `dataprep/validator` | Checks without transformation: `check`, `predicate`, `both`, `all`, `alt`, `guard`, `map_error`, `label`, `each`, `optional`. |
 | `dataprep/validated` | Applicative error accumulation: `map`, `map_error`, `and_then`, `from_result`, `from_result_map`, `to_result`, `map2`..`map5`, `sequence`, `traverse`, `traverse_indexed`. |
 | `dataprep/non_empty_list` | At-least-one guarantee for error lists: `single`, `cons`, `append`, `concat`, `map`, `flat_map`, `to_list`, `from_list`. |

--- a/src/dataprep/prep.gleam
+++ b/src/dataprep/prep.gleam
@@ -90,16 +90,42 @@ pub fn replace(
   fn(s) { string.replace(in: s, each: target, with: replacement) }
 }
 
-/// Replace the value with fallback when the input is exactly "".
+/// Replace the value with fallback when the input is exactly the
+/// literal empty string `""`.
 ///
-/// Note: this checks the literal empty string only. Whitespace-only
-/// inputs like "  " are NOT treated as empty. If you want
-/// whitespace-only values to trigger the default, compose with trim:
+/// Whitespace-only inputs like `" "`, `"\t"`, `"  \n  "` are
+/// **passed through unchanged** — only `s == ""` triggers the
+/// fallback. Reach for `default_when_blank` instead when you want
+/// the broader \"missing or whitespace-only\" check, or compose with
+/// `trim`:
 ///
 ///   prep.trim() |> prep.then(first: _, next: prep.default("N/A"))
 pub fn default(fallback: String) -> Prep(String) {
   fn(s) {
     case s {
+      "" -> fallback
+      _ -> s
+    }
+  }
+}
+
+/// Replace the value with fallback when the input is the literal
+/// empty string `""` **or** consists only of whitespace (per
+/// `string.trim`).
+///
+/// Examples that fire the fallback: `""`, `" "`, `"\t"`, `"\r\n"`,
+/// `"  \n  "`. Examples that do not: `"a"`, `" a "`, `"\t hello"`.
+///
+/// Equivalent to `prep.trim() |> prep.then(prep.default(fallback))`
+/// when the trimmed value is what the caller wants to keep on the
+/// non-blank path. The dedicated helper preserves the **original**
+/// (un-trimmed) input on the non-blank path, which matches the
+/// `default` posture: only substitute, never edit. Use the explicit
+/// `trim |> default` composition when the trimmed form is the
+/// desired output.
+pub fn default_when_blank(fallback: String) -> Prep(String) {
+  fn(s) {
+    case string.trim(s) {
       "" -> fallback
       _ -> s
     }

--- a/test/dataprep/prep_test.gleam
+++ b/test/dataprep/prep_test.gleam
@@ -168,6 +168,53 @@ pub fn default_whitespace_only_test() -> Nil {
   assert prepper("   ") == "   "
 }
 
+// `default` only fires on the literal empty string. Pin the boundary
+// so a future regression that broadens it (e.g. accepting `" "`)
+// flips the test red.
+pub fn default_pinned_literal_only_contract_test() -> Nil {
+  let prepper = prep.default("FALLBACK")
+  assert prepper("") == "FALLBACK"
+  assert prepper(" ") == " "
+  assert prepper("\t") == "\t"
+  assert prepper("abc") == "abc"
+}
+
+pub fn default_trim_then_default_composition_test() -> Nil {
+  // Documented composition for "fall back when blank, otherwise keep
+  // the trimmed form". This pattern is mentioned in the docstring; the
+  // test pins it so a `then` shape change cannot silently rot the doc.
+  let prepper = prep.trim() |> prep.then(first: _, next: prep.default("N/A"))
+  assert prepper("") == "N/A"
+  assert prepper("   ") == "N/A"
+  assert prepper("\t\n") == "N/A"
+  assert prepper("  hi  ") == "hi"
+}
+
+// --- default_when_blank ---
+
+pub fn default_when_blank_empty_test() -> Nil {
+  let prepper = prep.default_when_blank("N/A")
+  assert prepper("") == "N/A"
+}
+
+pub fn default_when_blank_whitespace_only_test() -> Nil {
+  let prepper = prep.default_when_blank("N/A")
+  assert prepper(" ") == "N/A"
+  assert prepper("\t") == "N/A"
+  assert prepper("  \n  ") == "N/A"
+  assert prepper("\r\n") == "N/A"
+}
+
+pub fn default_when_blank_non_blank_preserves_input_test() -> Nil {
+  // Non-blank: the original (un-trimmed) input is returned. The
+  // helper substitutes, it does not edit; reach for
+  // `trim |> default` if the trimmed form is what the caller wants.
+  let prepper = prep.default_when_blank("N/A")
+  assert prepper("hi") == "hi"
+  assert prepper("  hi  ") == "  hi  "
+  assert prepper("\thello\n") == "\thello\n"
+}
+
 // --- then (composition) ---
 
 pub fn then_test() -> Nil {


### PR DESCRIPTION
## Summary

`prep.default(fallback)` only fires on the literal empty string `""`. Whitespace-only inputs (`" "`, `"\t"`, `"\r\n"`) pass through unchanged. The existing docstring mentions a `prep.trim() |> prep.then(prep.default(...))` workaround, but the snippet is buried in a doc comment, not exercised by `gleam test`, and surprises users coming from ecosystems where \"default\" implies a blank check. This PR adds `prep.default_when_blank/1` as the explicit \"missing-or-whitespace\" sibling and pins the existing composition pattern with a test so it cannot rot.

## Changes

- `src/dataprep/prep.gleam`:
  - `default_when_blank(fallback)` (new) — falls back when `string.trim(s) == ""`. Returns the **original** (un-trimmed) input on the non-blank path so the helper *substitutes* but never *edits*.
  - `default(fallback)` docstring tightened: explicit list of inputs that fire (`""`) and inputs that don't (`" "`, `"\t"`, etc.). Cross-references `default_when_blank` and the `trim |> default` composition.
- `test/dataprep/prep_test.gleam`:
  - `default_pinned_literal_only_contract_test` — pins the four-case boundary (`""`, `" "`, `"\t"`, `"abc"`).
  - `default_trim_then_default_composition_test` — exercises the docstring's recommended composition end-to-end.
  - `default_when_blank_empty_test` / `_whitespace_only_test` / `_non_blank_preserves_input_test` — pin the new helper's contract.
- `README.md`:
  - Modules table updated to list `default_when_blank`.
  - New \"`default` vs `default_when_blank`\" subsection (under *Examples*) shows both helpers side-by-side, the input-preserving semantics, and the explicit `trim |> default` composition for the \"trimmed form on non-blank\" case.
- `CHANGELOG.md` — `[Unreleased]` documents the additive helper.

## Design Decisions

- **Substitute, don't edit.** `default_when_blank` returns the original input on the non-blank path. That mirrors `default`'s posture (only substitute the empty string) and keeps the helper composable with `trim` when the caller actually wants the trimmed form. Two flags collapsed into one decision tree at the call site:
  - blank → fallback
  - non-blank → keep original
  - want trimmed-on-non-blank? → `prep.trim() |> prep.then(prep.default(...))`
- **No `default_when_empty` rename.** Issue #52's acceptance criteria asks for `default_when_blank` specifically. The literal-empty contract on the existing `default` is intentional (doc-callout pinned by a regression test), so renaming would force every existing caller to pick a side.
- **README example layout.** The new subsection is placed inside *Examples* rather than as a top-level section because it sits between two illustrative recipes — discoverable but not promoted into the Quick start.

## Limitations

- `default_when_blank` uses `string.trim`, which trims Unicode whitespace per `gleam/string`'s contract. That is independent of #50's `collapse_space` ASCII-narrowing; \"blank\" here intentionally accepts the broader Unicode-whitespace definition because that's the natural reading of the helper's name.

Closes #52