### PR TITLE
chore(release): prepare v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-05-07
+
 ### Documentation
 
 - **architecture**: `doc/architecture.md` (new) — single page that

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "dataprep"
-version = "0.11.0"
+version = "0.12.0"
 description = "Composable, type-driven preprocessing and validation combinator library"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "dataprep" }


### PR DESCRIPTION
### Documentation

- **architecture**: `doc/architecture.md` (new) — single page that
  resolves the recurring "do I want a `Prep` or a `Validator`?"
  decision. Covers the decision table, why the library splits total
  transformations from fallible checks, the canonical Prep →
  Validator pipeline recipe, the type-changing `parse` →
  `validated.and_then` bridge, and a worked end-to-end signup form.
  The `prep` and `validator` module docstrings now cross-link to it.
  The recipe is exercised by `test/integration_pipeline_test.gleam`
  so the snippet cannot drift out of sync. (#51)

### Added

- **prep**: `prep.default_when_blank(fallback)` falls back when the
  input is the literal empty string **or** whitespace-only (per
  `string.trim`). The existing `prep.default(fallback)` keeps its
  literal-empty-only contract; pick the right tool side-by-side via
  the new "`default` vs `default_when_blank`" README section. The
  documented `prep.trim() |> prep.then(prep.default(...))` composition
  is now exercised by `gleam test` so the example cannot rot. (#52)
- **prep**: `prep.collapse_unicode_space()` collapses runs of Unicode
  whitespace (`\s+` under the regex engine's full Unicode rule, so
  NO-BREAK SPACE, IDEOGRAPHIC SPACE, EN/EM spaces, etc. all match)
  into a single ASCII space. Reach for this when callers actually
  want the broader fold; the default `collapse_space` no longer does
  it. (#50)

### Changed

- **Breaking (prep)**: `prep.collapse_space()` now matches **ASCII
  whitespace only** (`[ \t\n\r\f\v]`). Previously it used `\s+`,
  which under the Erlang regex engine matches Unicode whitespace too
  and silently rewrote NO-BREAK SPACE (U+00A0) and IDEOGRAPHIC SPACE
  (U+3000) to a regular ASCII space — destructive in CJK contexts
  where `姓　名` (with U+3000 between names) would become `姓 名`
  with no warning. The Unicode-aware behaviour is still available as
  `prep.collapse_unicode_space()` for callers who need it. (#50)

### Fixed

- **rules**: `matches_fully_string` and `matches_fully_string_checked`
  now correctly accept inputs that match a non-leftmost branch of a
  top-level alternation. The pattern is anchored as `^(?:pattern)$`
  inside the helper before compilation, so e.g. `"a|ab"` against
  `"ab"` is now `Valid` (matching Python `re.fullmatch` semantics)
  instead of being rejected because `regexp.scan` chose the shorter
  `a` alternative. The compiled-regex variant `matches_fully` cannot
  be fixed in place — `Regexp` is opaque and the source pattern is
  unrecoverable — so its docstring now documents the alternation
  caveat and points callers at the `_string` / `_string_checked`
  variants. (#47)
