### PR TITLE
docs(validator): pin empty-list monoid identity for all/1 and prep.sequence/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- **validator / prep**: pin the empty-list monoid identity in the
+  docstrings of `validator.all/1` and `prep.sequence/1`. Both
+  functions return the identity element when given `[]` (`Valid(a)`
+  and `identity()` respectively); the docs now explain that this is
+  a deliberate monoid law and recommend
+  `validator.predicate(fn(_) { True }, _)` for callers who want an
+  *explicit* pass-through validator. The existing
+  `law_all_empty_is_identity_test` keeps the validator side under
+  test; a new `law_prep_sequence_empty_is_identity_test` pins the
+  prep side. (#57)
+
 ## [0.12.0] - 2026-05-07
 
 ### Documentation

--- a/src/dataprep/prep.gleam
+++ b/src/dataprep/prep.gleam
@@ -25,7 +25,14 @@ pub fn then(first p1: Prep(a), next p2: Prep(a)) -> Prep(a) {
 }
 
 /// Compose a list of preps into a single prep.
-/// Empty list returns identity.
+///
+/// `identity()` is the identity element of sequential composition,
+/// so `sequence([])` returns a prep that leaves every input
+/// unchanged. This is a deliberate monoid law (see
+/// `test/dataprep/laws_test.gleam`) and lets callers build prep
+/// lists incrementally — for example via
+/// `list.filter(all_preps, by_feature_flag)` — without a special
+/// case when the resulting list happens to be empty.
 pub fn sequence(steps: List(Prep(a))) -> Prep(a) {
   list.fold(over: steps, from: identity(), with: fn(acc, step) {
     then(first: acc, next: step)

--- a/src/dataprep/validator.gleam
+++ b/src/dataprep/validator.gleam
@@ -60,6 +60,19 @@ pub fn both(
 }
 
 /// Run all validators on the same input. Accumulate all errors.
+///
+/// `Valid(a)` is the identity element of accumulation, so
+/// `all([])` returns a validator that accepts every input
+/// without producing any errors. This is a deliberate monoid law
+/// (see `test/dataprep/laws_test.gleam`) and lets callers build
+/// validator lists incrementally — for example via
+/// `list.filter(all_validators, by_feature_flag)` — without a
+/// special case when the resulting list happens to be empty.
+///
+/// If you want an *explicit* pass-through validator, prefer
+/// `validator.predicate(fn(_) { True }, _)` so the intent is
+/// visible at the call site instead of relying on the empty-list
+/// identity.
 pub fn all(validators: List(Validator(a, e))) -> Validator(a, e) {
   fn(a) {
     list.fold(validators, Valid(a), fn(acc, v) {

--- a/test/dataprep/laws_test.gleam
+++ b/test/dataprep/laws_test.gleam
@@ -12,6 +12,7 @@
 
 import dataprep/helpers/nel
 import dataprep/non_empty_list
+import dataprep/prep
 import dataprep/validated.{type Validated, Invalid, Valid}
 import dataprep/validator
 import gleam/list
@@ -371,4 +372,31 @@ pub fn law_sequence_accumulates_in_order_test() -> Nil {
   // empty input is Valid([])
   let empty: List(Validated(Int, LawErr)) = []
   assert validated.sequence(empty) == Valid([])
+}
+
+// ---------------------------------------------------------------------------
+// Prep combinator laws
+// ---------------------------------------------------------------------------
+
+// Law: `prep.sequence([])` is the identity element of sequential
+// composition.
+//   For every input x: sequence([])(x) = x.
+//
+// This pairs with `validator.all([])` returning `Valid(_)` (the
+// accumulation identity): both monoid units are accessible via the
+// empty-list case so callers can build prep / validator lists
+// incrementally without special-casing emptiness.
+pub fn law_prep_sequence_empty_is_identity_test() -> Nil {
+  assert prep.sequence([])(42) == 42
+  assert prep.sequence([])("x") == "x"
+  assert prep.sequence([])(option.None) == option.None
+  // Composing identity with a real prep equals the prep itself for
+  // every input — confirms `sequence([])` does not perturb a later
+  // composition.
+  let trim_then_lower = prep.then(first: prep.trim(), next: prep.lowercase())
+  let with_empty_prefix =
+    prep.then(first: prep.sequence([]), next: trim_then_lower)
+  list.each(["", "  HELLO  ", "X"], fn(s) {
+    assert with_empty_prefix(s) == trim_then_lower(s)
+  })
 }


### PR DESCRIPTION
## Summary

Documents the empty-list behaviour of `validator.all/1` and `prep.sequence/1` as a deliberate monoid law (the identity element of accumulation / sequential composition). Closes #57.

## Changes

- `src/dataprep/validator.gleam`: `all/1` docstring now explains that `Valid(a)` is the identity of accumulation, so `all([])` returns a vacuous-pass validator on purpose. The doc cross-references the existing `law_all_empty_is_identity_test` and recommends `validator.predicate(fn(_) { True }, _)` for callers who want an *explicit* pass-through (so the intent is visible at the call site).
- `src/dataprep/prep.gleam`: `sequence/1` docstring expanded with the same monoid-identity framing for `identity()` as the unit of `then`.
- `test/dataprep/laws_test.gleam`: imports `dataprep/prep` and adds `law_prep_sequence_empty_is_identity_test`. The test pins `sequence([])(x) == x` for several input shapes and confirms that composing `sequence([])` with a real prep does not perturb the later composition.
- `CHANGELOG.md`: `[Unreleased]` entry under `### Documentation`.

## Design Decisions

- **Doc-only over panic.** Issue #57 listed both options ("Strict" panic vs "Doc-only" docstring). The codebase already pins `validator.all([])(x) == Valid(x)` as `law_all_empty_is_identity_test` and `prep.sequence/1` already declared "Empty list returns identity" — the project has *committed* to the monoid identity at the law level, so panicking would invalidate a deliberate design choice. The fix here is to make that intent legible from the docstring (and surrounding tests) rather than reverse it.
- **No `predicate(fn(_) { True }, _)` helper added.** The Issue suggested it as the recommended explicit pass-through; since `predicate` already covers the case in one line, we point at it instead of wrapping it in a new export.
- **Symmetric treatment of `prep.sequence/1`.** The Issue acknowledged the dual situation in `prep.sequence`. Pinning the law explicitly via a new test prevents a future refactor from silently flipping the rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified the behavior of validators and data preparation functions when processing empty lists. These operations now explicitly follow monoid identity laws, ensuring inputs remain unchanged. Added usage guidance for implementing explicit pass-through validators.

* **Tests**
  * Added comprehensive tests to verify empty-list operations correctly implement monoid identity laws across all supported data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->