### PR TITLE
chore(release): prepare v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-05-07
+
 ### Documentation
 
 - **validator / prep**: pin the empty-list monoid identity in the

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "dataprep"
-version = "0.12.0"
+version = "0.13.0"
 description = "Composable, type-driven preprocessing and validation combinator library"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "dataprep" }


### PR DESCRIPTION
### Documentation

- **validator / prep**: pin the empty-list monoid identity in the
  docstrings of `validator.all/1` and `prep.sequence/1`. Both
  functions return the identity element when given `[]` (`Valid(a)`
  and `identity()` respectively); the docs now explain that this is
  a deliberate monoid law and recommend
  `validator.predicate(fn(_) { True }, _)` for callers who want an
  *explicit* pass-through validator. The existing
  `law_all_empty_is_identity_test` keeps the validator side under
  test; a new `law_prep_sequence_empty_is_identity_test` pins the
  prep side. (#57)
