### PR TITLE
docs(prep): add 'Applying a Prep' section + prep.run/2 alias (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **prep**: `prep.run(prep:, value:)` is a thin alias for the
+  function-call form: `prep.run(p, value)` is identical to `p(value)`.
+  `Prep(a)` is a `fn(a) -> a` type alias, so applying a built prep is
+  just calling it like a function — but new users coming from a "build
+  a transformer, apply later" mental model reach for `run`/`apply`
+  first. `prep.run/2` exists as a discoverability hook (and as a
+  pipe-friendly entry point for callers who thread the prep value
+  through multiple call sites). Both forms compile to the same code;
+  pick whichever reads better at the call site. (#60)
+
+### Documentation
+- **prep**: top-level `////` docstring now ships an "Applying a Prep"
+  section that pins the type-alias trick (`Prep(a) = fn(a) -> a`),
+  shows the function-call form, and points readers at `prep.run/2`
+  for the named entry point. The split lets readers pick whichever
+  form reads better at the call site without having to read the
+  source to learn the type-alias contract. (#60)
+
 ## [0.13.0] - 2026-05-07
 
 ### Documentation

--- a/src/dataprep/prep.gleam
+++ b/src/dataprep/prep.gleam
@@ -9,6 +9,23 @@
 //// see [`doc/architecture.md`](../../doc/architecture.md) for the
 //// decision table, the canonical Prep → Validator pipeline recipe,
 //// and a worked end-to-end example.
+////
+//// ## Applying a Prep
+////
+//// `Prep(a)` is a type alias for `fn(a) -> a`, so applying a built
+//// prep is **just calling it like a function** — no wrapper module
+//// function is needed:
+////
+//// ```gleam
+//// let pipeline = prep.then(first: prep.trim(), next: prep.uppercase())
+//// let cleaned = pipeline(\"  hello  \")  // \"HELLO\"
+//// ```
+////
+//// For readers who prefer a named entry point — pipeline-style or
+//// when threading a prep through multiple call sites — `prep.run/2`
+//// is a thin alias of the function call: `prep.run(pipeline, value)`
+//// is identical to `pipeline(value)`. Pick whichever reads better at
+//// your call site; both compile to the same code.
 
 import gleam/list
 import gleam/regexp
@@ -42,6 +59,17 @@ pub fn sequence(steps: List(Prep(a))) -> Prep(a) {
 /// No-op prep. Returns the value unchanged.
 pub fn identity() -> Prep(a) {
   fn(x) { x }
+}
+
+/// Apply a `Prep(a)` to a value. Thin alias of the function call:
+/// `prep.run(p, value)` is identical to `p(value)`. The two forms
+/// compile to the same code; reach for `run/2` when a named entry
+/// point reads better at the call site (pipelines, currying, threading
+/// the prep value through multiple call sites). Discoverability hook
+/// for users who grep for "apply" / "run" before learning the type
+/// alias trick (#60).
+pub fn run(prep prep: Prep(a), value value: a) -> a {
+  prep(value)
 }
 
 /// Trim leading and trailing whitespace.

--- a/test/dataprep/prep_test.gleam
+++ b/test/dataprep/prep_test.gleam
@@ -279,3 +279,22 @@ pub fn full_pipeline_test() -> Nil {
     ])
   assert clean("  John.  DOE.  Jr  ") == "john doe jr"
 }
+
+// --- run/2: discoverability hook for the function-call form (#60) ---
+
+pub fn run_is_function_call_test() -> Nil {
+  let pipeline = prep.then(first: prep.trim(), next: prep.uppercase())
+  // run/2 must be byte-identical to calling the prep value directly.
+  assert prep.run(pipeline, "  hello  ") == pipeline("  hello  ")
+}
+
+pub fn run_with_identity_test() -> Nil {
+  // identity()'s `run` is the identity function on the value.
+  assert prep.run(prep.identity(), "untouched") == "untouched"
+}
+
+pub fn run_with_sequence_test() -> Nil {
+  let clean =
+    prep.sequence([prep.trim(), prep.lowercase(), prep.collapse_space()])
+  assert prep.run(clean, "  John.  DOE.  Jr  ") == "john. doe. jr"
+}


### PR DESCRIPTION
## Summary

`Prep(a)` is a `fn(a) -> a` type alias, so applying a built prep is just calling it like a function. New users coming from a "build, apply later" mental model reach for `run`/`apply` first and only learn the trick after reading the source. This PR adds a short "Applying a Prep" section to the module docstring and exposes `prep.run/2` as a thin alias of the function call. Both forms compile to the same code; the alias exists purely for discoverability and pipe-friendliness. Closes #60.

## Changes

- `src/dataprep/prep.gleam`
  - Top-level `////` docstring gains an "Applying a Prep" subsection that pins the type-alias trick, shows the function-call form, and points at `prep.run/2`.
  - New `pub fn run(prep prep: Prep(a), value value: a) -> a { prep(value) }` — labelled both sides for `glinter`'s `label_possible` rule (positional invocation still works).
- `test/dataprep/prep_test.gleam`
  - Three new tests pinning that `prep.run(p, value)` is byte-identical to `p(value)` for `identity`, a 2-step `then`, and a 3-step `sequence`.
- `CHANGELOG.md`: documents the alias and the docstring change under `[Unreleased]`.

## Design Decisions

- **Alias instead of replacement**: `then`/`sequence`/the function-call form are unchanged. The alias is additive; existing call sites are not touched. Removing or renaming any existing API would have been a breaking change for a discoverability-only fix.
- **`run` over `apply`**: matches `validator.predicate(...) → Validator(a, e) → fn(a) -> Validated(a, e)` mental model where the validator is "run" against an input. Also avoids the `apply` overload in the language's stdlib (`option.apply`, `dict.apply`).
- **Labelled both-sides** (`prep prep:`, `value value:`): keeps `glinter`'s `label_possible` rule happy without forcing the label on the call site (Gleam still accepts positional when every label is present).

## Limitations

None. The change is additive and the existing function-call form remains the canonical implementation — `run/2` literally inlines to it.

Closes #60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `prep.run()` as a named, pipe-friendly alternative for applying prep transformations.

* **Documentation**
  * Updated documentation with an "Applying a Prep" section including usage guidance and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->