### PR TITLE
feat(prep): add compose/2 alias of then/2 for FP discoverability (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **prep**: `prep.compose(first:, then:)` is a labelled alias of
+  `prep.then/2` exposed under the FP `compose` name. FP-leaning users
+  coming from Haskell `(.)`, Elm `<<`, or lodash `_.flow` grep for
+  `compose` first; the alias keeps the entry point discoverable via
+  hexdocs / autocomplete without renaming or removing the existing
+  `then/2`. Output is byte-identical to `then(first:, next:)`. The
+  second label reads `then` (not `next`) to mirror the prose "first
+  do f, *then* do g". (#61)
+
 - **prep**: `prep.run(prep:, value:)` is a thin alias for the
   function-call form: `prep.run(p, value)` is identical to `p(value)`.
   `Prep(a)` is a `fn(a) -> a` type alias, so applying a built prep is

--- a/src/dataprep/prep.gleam
+++ b/src/dataprep/prep.gleam
@@ -37,8 +37,22 @@ pub type Prep(a) =
   fn(a) -> a
 
 /// Sequential composition: apply p1, then apply p2 to the result.
+///
+/// FP-leaning users often grep for `compose` first; `prep.compose/2`
+/// is a labelled alias of this function with the same semantics.
+/// Both forms accept positional and labelled arguments.
 pub fn then(first p1: Prep(a), next p2: Prep(a)) -> Prep(a) {
   fn(x) { p2(p1(x)) }
+}
+
+/// Sequential composition: same as `then/2`, exposed under the FP
+/// `compose` name so callers coming from Haskell `(.)`, Elm `<<`,
+/// or lodash `_.flow` find the entry point on first grep. The label
+/// reads `compose(first:, then:)` — the second label is `then` (not
+/// `next`) to mirror the prose "first do f, *then* do g". Output is
+/// byte-identical to `then(first:, next:)`. (#61)
+pub fn compose(first p1: Prep(a), then p2: Prep(a)) -> Prep(a) {
+  then(first: p1, next: p2)
 }
 
 /// Compose a list of preps into a single prep.

--- a/test/dataprep/prep_test.gleam
+++ b/test/dataprep/prep_test.gleam
@@ -280,6 +280,44 @@ pub fn full_pipeline_test() -> Nil {
   assert clean("  John.  DOE.  Jr  ") == "john doe jr"
 }
 
+// --- compose/2: FP-named alias of then/2 (#61) ---
+
+pub fn compose_matches_then_test() -> Nil {
+  let via_then = prep.then(first: prep.trim(), next: prep.uppercase())
+  let via_compose = prep.compose(first: prep.trim(), then: prep.uppercase())
+  // Same input must produce the same output via either entry point.
+  assert via_then("  hello  ") == via_compose("  hello  ")
+  assert via_then("  hello  ") == "HELLO"
+}
+
+pub fn compose_with_default_test() -> Nil {
+  let pipeline = prep.compose(first: prep.trim(), then: prep.default("N/A"))
+  assert pipeline("   ") == "N/A"
+  assert pipeline("hello") == "hello"
+  assert pipeline("") == "N/A"
+}
+
+pub fn compose_associativity_with_then_test() -> Nil {
+  // (trim ∘ lowercase) ∘ collapse must equal trim ∘ (lowercase ∘ collapse)
+  // for total transformations on the same type — pinning the monoid
+  // law on the alias side.
+  let trim_step = prep.trim()
+  let lower_step = prep.lowercase()
+  let collapse_step = prep.collapse_space()
+  let left =
+    prep.compose(
+      first: prep.compose(first: trim_step, then: lower_step),
+      then: collapse_step,
+    )
+  let right =
+    prep.compose(
+      first: trim_step,
+      then: prep.compose(first: lower_step, then: collapse_step),
+    )
+  let input = "  Hello   WORLD  "
+  assert left(input) == right(input)
+}
+
 // --- run/2: discoverability hook for the function-call form (#60) ---
 
 pub fn run_is_function_call_test() -> Nil {


### PR DESCRIPTION
## Summary

Adds `prep.compose(first:, then:)` as a labelled alias of `prep.then(first:, next:)`. FP-leaning users (Haskell `(.)`, Elm `<<`, lodash `_.flow`) grep for `compose` first; the alias keeps the entry point discoverable via hexdocs/autocomplete without renaming the existing `then/2`. Output is byte-identical to `then`. Closes #61.

## Changes

- `src/dataprep/prep.gleam`
  - New `pub fn compose(first p1: Prep(a), then p2: Prep(a)) -> Prep(a) { then(first: p1, next: p2) }`. Second label reads `then` (not `next`) so the call site reads "first do f, *then* do g" naturally.
  - `then/2` doc string gains a one-line cross-reference to `compose/2` so users who land on either function find both.
- `test/dataprep/prep_test.gleam`
  - Three new tests: parity with `then/2` on a 2-step pipeline, idempotence with `default`, monoid associativity (`(f ∘ g) ∘ h ≡ f ∘ (g ∘ h)`) on the alias path.
- `CHANGELOG.md`: documents the alias under `[Unreleased]`.

## Design Decisions

- **Alias, not replacement.** Existing `then/2` callers are not touched; `compose/2` is purely additive. The two names point at the same primitive, which keeps the docs honest and lets each user pick the one that reads better.
- **Label `then` (not `next`).** `compose(first: trim, then: uppercase)` reads as the prose "first trim, then uppercase". Reusing `next` would be technically consistent with `then/2` but reads awkward at the call site (`compose(first: trim, next: uppercase)` — "next" is what you do after "first", but the natural English here is "then").
- **Implementation forwards to `then/2`.** Single source of truth — any future change to the composition semantics flows through one function. Output is byte-identical and the compiler will inline.

## Limitations

None. Additive change; existing call sites unchanged.

Closes #61