### PR TITLE
feat(validator): add required for canonical non-empty string check (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **validator**: `validator.required(error)` is a convenience for the
+  canonical "this string field is required" check —
+  `predicate(fn(s) { s != "" }, error)` spelt out as the intent rather
+  than the implementation. Pairs naturally with `prep.trim()` upstream
+  for the "required after trimming" posture. Scoped to `String` because
+  "required for `Option(a)`" and "required for a list" are different
+  shapes (use `optional/1` flipped or `predicate(fn(xs) { xs != [] })`,
+  respectively). (#62)
+
 - **prep**: `prep.compose(first:, then:)` is a labelled alias of
   `prep.then/2` exposed under the FP `compose` name. FP-leaning users
   coming from Haskell `(.)`, Elm `<<`, or lodash `_.flow` grep for

--- a/src/dataprep/validator.gleam
+++ b/src/dataprep/validator.gleam
@@ -42,6 +42,31 @@ pub fn predicate(condition: fn(a) -> Bool, error: e) -> Validator(a, e) {
   })
 }
 
+/// Reject the empty string. Convenience for the most common form-
+/// validation case: "this field must be non-empty". Equivalent to
+/// `predicate(fn(s) { s != "" }, error)` but reads at the call site
+/// as the intent ("required") rather than the implementation
+/// ("predicate that the string is not the empty string"). (#62)
+///
+/// Pairs naturally with `prep.trim()` upstream when the desired
+/// posture is "required after trimming whitespace":
+///
+/// ```gleam
+/// let normalised = prep.trim() |> prep.run("  ")
+/// // normalised == ""
+/// case validator.required("project is required")(normalised) {
+///   validated.Valid(_) -> ...
+///   validated.Invalid(_) -> // rejected
+/// }
+/// ```
+///
+/// Scoped to `String` because "required for `Option(a)`" and
+/// "required for a list" are different shapes (`Option` → flip
+/// `optional/1`; list → `predicate(fn(xs) { xs != [] }, error)`).
+pub fn required(error: e) -> Validator(String, e) {
+  predicate(fn(s) { s != "" }, error)
+}
+
 /// Run both validators on the same input. Accumulate all errors.
 /// On success, return the (unchanged) input.
 pub fn both(

--- a/test/dataprep/validator_test.gleam
+++ b/test/dataprep/validator_test.gleam
@@ -505,3 +505,46 @@ pub fn optional_composes_with_all_over_parent_option_test() -> Nil {
   assert validator_under_test(option.Some("ab"))
     == Invalid(non_empty_list.single(TooShort))
 }
+
+// --- required: convenience for the canonical "non-empty string" check (#62) ---
+
+pub fn required_rejects_empty_string_test() -> Nil {
+  let validator_under_test = validator.required(IsEmpty)
+  assert validator_under_test("") == Invalid(non_empty_list.single(IsEmpty))
+}
+
+pub fn required_accepts_non_empty_string_test() -> Nil {
+  let validator_under_test = validator.required(IsEmpty)
+  assert validator_under_test("hello") == Valid("hello")
+}
+
+pub fn required_accepts_whitespace_only_string_test() -> Nil {
+  // Whitespace-only is non-empty by string equality, so `required`
+  // alone accepts it. Callers who want "required after trimming"
+  // pipe through `prep.trim` upstream — documented in the validator
+  // doc comment.
+  let validator_under_test = validator.required(IsEmpty)
+  assert validator_under_test("   ") == Valid("   ")
+}
+
+pub fn required_matches_predicate_form_test() -> Nil {
+  // The convenience must produce byte-identical Validated values to
+  // the spelt-out predicate form on the same inputs.
+  let via_required = validator.required(IsEmpty)
+  let via_predicate = validator.predicate(fn(s) { s != "" }, IsEmpty)
+  assert via_required("") == via_predicate("")
+  assert via_required("ok") == via_predicate("ok")
+  assert via_required(" ") == via_predicate(" ")
+}
+
+pub fn required_composes_with_all_test() -> Nil {
+  let validator_under_test =
+    validator.all([
+      validator.required(IsEmpty),
+      validator.predicate(fn(s) { string.length(s) <= 32 }, TooLong),
+    ])
+  assert validator_under_test("ok") == Valid("ok")
+  // Empty triggers IsEmpty; the >32 check passes for "" so only
+  // IsEmpty surfaces.
+  assert validator_under_test("") == Invalid(non_empty_list.single(IsEmpty))
+}


### PR DESCRIPTION
## Summary

Adds `validator.required(error) -> Validator(String, e)` as the labelled shortcut for the most common form-validation case: "this string field must be non-empty". Equivalent to `predicate(fn(s) { s != "" }, error)` but reads at the call site as the intent rather than the implementation. Closes #62.

## Changes

- `src/dataprep/validator.gleam`: new `pub fn required(error: e) -> Validator(String, e)`. Doc comment cites the `prep.trim()` pairing for "required after trimming" and the scoping rationale (why `String`-only).
- `test/dataprep/validator_test.gleam`: 5 new tests — empty rejected, non-empty accepted, whitespace-only accepted (documenting the trim-pairing convention), parity with the spelt-out `predicate` form, composition with `validator.all` alongside a `TooLong` rule.
- `CHANGELOG.md`: documents the addition under `[Unreleased]`.

## Design Decisions

- **Scoped to `String`**, not generic. "Required for `Option(a)`" is a different shape (use `optional/1` flipped) and "required for a list" is `predicate(fn(xs) { xs != [] }, error)` — both have different ergonomics. Documenting "required" as the canonical empty-string check keeps the contract crisp.
- **`required(error)` over `required(field:, message:)`**. The earlier issue sketch suggested a labelled `field:` argument as a documentation hint, but `field`/`label` machinery already exists via `validator.label/2` and forcing the convenience to carry it would split the labelling story across two functions. The simpler `required(error)` is consistent with `predicate(condition, error)` next door.
- **Whitespace-only is accepted by default**. The convention in `dataprep` is "prep transforms first, validator checks second": piping through `prep.trim()` upstream gives the "required after trimming" posture without having `required` make assumptions. Documented in the doc comment with a worked example.

## Limitations

None. Additive change; existing call sites are unaffected. The earlier `predicate(fn(s) { s != "" }, error)` form continues to work identically.

Closes #62