### PR TITLE
chore(release): prepare v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-05-08
+
 ### Added
 - **validator**: `validator.required(error)` is a convenience for the
   canonical "this string field is required" check —

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "dataprep"
-version = "0.13.0"
+version = "0.14.0"
 description = "Composable, type-driven preprocessing and validation combinator library"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "dataprep" }


### PR DESCRIPTION
### Added
- **validator**: `validator.required(error)` is a convenience for the
  canonical "this string field is required" check —
  `predicate(fn(s) { s != "" }, error)` spelt out as the intent rather
  than the implementation. Pairs naturally with `prep.trim()` upstream
  for the "required after trimming" posture. Scoped to `String` because
  "required for `Option(a)`" and "required for a list" are different
  shapes (use `optional/1` flipped or `predicate(fn(xs) { xs != [] })`,
  respectively). (#62)

- **prep**: `prep.compose(first:, then:)` is a labelled alias of
  `prep.then/2` exposed under the FP `compose` name. FP-leaning users
  coming from Haskell `(.)`, Elm `<<`, or lodash `_.flow` grep for
  `compose` first; the alias keeps the entry point discoverable via
  hexdocs / autocomplete without renaming or removing the existing
  `then/2`. Output is byte-identical to `then(first:, next:)`. The
  second label reads `then` (not `next`) to mirror the prose "first
  do f, *then* do g". (#61)

- **prep**: `prep.run(prep:, value:)` is a thin alias for the
  function-call form: `prep.run(p, value)` is identical to `p(value)`.
  `Prep(a)` is a `fn(a) -> a` type alias, so applying a built prep is
  just calling it like a function — but new users coming from a "build
  a transformer, apply later" mental model reach for `run`/`apply`
  first. `prep.run/2` exists as a discoverability hook (and as a
  pipe-friendly entry point for callers who thread the prep value
  through multiple call sites). Both forms compile to the same code;
  pick whichever reads better at the call site. (#60)

### Documentation
- **prep**: top-level `////` docstring now ships an "Applying a Prep"
  section that pins the type-alias trick (`Prep(a) = fn(a) -> a`),
  shows the function-call form, and points readers at `prep.run/2`
  for the named entry point. The split lets readers pick whichever
  form reads better at the call site without having to read the
  source to learn the type-alias contract. (#60)
