### PR TITLE
feat(parse): add parse.float_strict for end-to-end float validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`dataprep/parse`**: `parse.float_strict(raw, on_error)` is the
+  strict counterpart of `parse.float`. The lenient variant delegates
+  to `gleam/float.parse`, which silently truncates inputs like
+  `"3,000"` to `3.0` (parse stops at the comma) — a 1000× wrong
+  amount for users typing locale-formatted thousand-separated values
+  in `de_DE` / `fr_FR` / `ja_JP`. The strict variant validates the
+  input with a strict-float grammar
+  (`-?(\d+|\d+\.\d+)([eE]-?\d+)?`) and rejects anything else
+  (commas, spaces, trailing letters, leading dots, multiple dots).
+  `parse.float` keeps its lenient shape for backward compatibility,
+  with an updated doc-comment that warns about the locale-truncation
+  footgun and points at `float_strict` for amount fields. (#67)
 - Property-based and metamorphic tests using
   [metamon](https://github.com/nao1215/metamon) covering the public
   surface of `dataprep/prep`, `dataprep/non_empty_list`, and

--- a/src/dataprep/parse.gleam
+++ b/src/dataprep/parse.gleam
@@ -3,8 +3,10 @@
 /// + result.map_error + validated.from_result.
 import dataprep/non_empty_list
 import dataprep/validated.{type Validated, Invalid, Valid}
+import gleam/bool
 import gleam/float
 import gleam/int
+import gleam/regexp
 import gleam/result
 import gleam/string
 
@@ -24,14 +26,25 @@ pub fn int(raw: String, on_error: fn(String) -> e) -> Validated(Int, e) {
 /// Parse a string as Float. On failure, call `on_error` with the
 /// original string to produce the error value.
 ///
-/// Accepts every shape `gleam/float.parse` accepts (e.g. `"3.14"`,
-/// `"-0.5"`) and additionally accepts:
+/// **Lenient.** Accepts every shape `gleam/float.parse` accepts
+/// (e.g. `"3.14"`, `"-0.5"`) and additionally accepts:
 ///
 /// - integer literals — `"5"` parses as `5.0` (asymmetric strictness
 ///   between `parse.int` and `parse.float` was a UX trap when the
 ///   raw input is a user-typed numeric value).
 /// - scientific notation — `"1e3"`, `"1.5e-2"`, `"5E3"` are all
 ///   accepted; the exponent must itself be a valid integer.
+///
+/// **Locale ambiguity warning.** `gleam/float.parse` is documented as
+/// lenient: it returns the parsed prefix when the input has trailing
+/// non-numeric bytes. Concretely, `parse.float("3,000", ...)` returns
+/// `Valid(3.0)` because the parse stops at the comma. This silently
+/// truncates locale-formatted thousand-separated input
+/// (`de_DE` / `fr_FR` / `ja_JP` users typing `"3,000"` mean three
+/// thousand, not three) and a 1000× wrong amount can flow through
+/// the rest of the pipeline. For amount fields, address fields, and
+/// any other input where partial-parse is a bug rather than a
+/// feature, use `float_strict/2` instead. (#67)
 ///
 /// Example:
 ///   parse.float(raw, fn(s) { NotAFloat(s) })
@@ -41,6 +54,48 @@ pub fn float(raw: String, on_error: fn(String) -> e) -> Validated(Float, e) {
     Ok(x) -> Valid(x)
     Error(Nil) -> Invalid(non_empty_list.single(on_error(raw)))
   }
+}
+
+/// Parse a string as Float, rejecting any input the strict-float
+/// grammar does not accept end-to-end.
+///
+/// Strict counterpart of `float/2`. The lenient `float/2` delegates
+/// to `gleam/float.parse`, which silently truncates inputs like
+/// `"3,000"` (returns `3.0`, parse stops at the comma). For form
+/// fields where partial-parse is a bug, use this variant.
+///
+/// Accepts: optional leading `-`, then digits (`"42"`) or
+/// digits-dot-digits (`"3.14"`), optionally followed by a scientific
+/// suffix (`[eE]-?\d+`, e.g. `"1.5e-2"`, `"5E3"`). Anything else —
+/// commas, spaces, trailing letters, leading dots, multiple dots —
+/// is rejected via `on_error`.
+///
+/// Example:
+///   parse.float_strict("3,000", fn(s) { NotAFloat(s) })
+///   // Invalid([NotAFloat("3,000")])  -- not Valid(3.0)
+///
+/// Equivalent to `float/2` for inputs the strict grammar accepts;
+/// callers can opt into strictness without rewriting their error
+/// type.
+pub fn float_strict(
+  raw: String,
+  on_error: fn(String) -> e,
+) -> Validated(Float, e) {
+  use <- bool.guard(
+    when: !strict_float_grammar_matches(raw),
+    return: Invalid(non_empty_list.single(on_error(raw))),
+  )
+  case parse_lenient_float(raw) {
+    Ok(value) -> Valid(value)
+    Error(Nil) -> Invalid(non_empty_list.single(on_error(raw)))
+  }
+}
+
+fn strict_float_grammar_matches(raw: String) -> Bool {
+  // nolint: assert_ok_pattern -- the strict-float regex is a fixed, known-valid literal
+  let assert Ok(strict_re) =
+    regexp.from_string("^-?(?:\\d+\\.\\d+|\\d+)(?:[eE]-?\\d+)?$")
+  regexp.check(with: strict_re, content: raw)
 }
 
 fn parse_lenient_float(raw: String) -> Result(Float, Nil) {

--- a/test/dataprep/parse_test.gleam
+++ b/test/dataprep/parse_test.gleam
@@ -111,6 +111,91 @@ pub fn float_rejects_garbage_with_e_test() -> Nil {
     == Invalid(non_empty_list.single(NotAFloat("abc")))
 }
 
+// --- parse.float_strict (#67) ---
+
+pub fn float_strict_pass_test() -> Nil {
+  assert parse.float_strict("3.14", NotAFloat) == Valid(3.14)
+}
+
+pub fn float_strict_negative_test() -> Nil {
+  assert parse.float_strict("-1.5", NotAFloat) == Valid(-1.5)
+}
+
+pub fn float_strict_integer_literal_test() -> Nil {
+  assert parse.float_strict("5", NotAFloat) == Valid(5.0)
+}
+
+pub fn float_strict_zero_test() -> Nil {
+  assert parse.float_strict("0", NotAFloat) == Valid(0.0)
+}
+
+pub fn float_strict_scientific_test() -> Nil {
+  assert parse.float_strict("1.5e-2", NotAFloat) == Valid(0.015)
+}
+
+pub fn float_strict_scientific_uppercase_test() -> Nil {
+  assert parse.float_strict("5E3", NotAFloat) == Valid(5000.0)
+}
+
+pub fn float_strict_rejects_thousand_separator_comma_test() -> Nil {
+  // The whole point of float_strict: lenient parse silently returns
+  // 3.0 here; strict must reject so locale-formatted thousand
+  // separators don't slide through as 1000x-too-small values.
+  assert parse.float_strict("3,000", NotAFloat)
+    == Invalid(non_empty_list.single(NotAFloat("3,000")))
+}
+
+pub fn float_strict_rejects_space_separator_test() -> Nil {
+  assert parse.float_strict("3 000", NotAFloat)
+    == Invalid(non_empty_list.single(NotAFloat("3 000")))
+}
+
+pub fn float_strict_rejects_trailing_letters_test() -> Nil {
+  assert parse.float_strict("12.50abc", NotAFloat)
+    == Invalid(non_empty_list.single(NotAFloat("12.50abc")))
+}
+
+pub fn float_strict_rejects_unit_suffix_test() -> Nil {
+  assert parse.float_strict("3K", NotAFloat)
+    == Invalid(non_empty_list.single(NotAFloat("3K")))
+}
+
+pub fn float_strict_rejects_empty_test() -> Nil {
+  assert parse.float_strict("", NotAFloat)
+    == Invalid(non_empty_list.single(NotAFloat("")))
+}
+
+pub fn float_strict_rejects_leading_dot_test() -> Nil {
+  // The strict grammar requires digits before the dot.
+  assert parse.float_strict(".5", NotAFloat)
+    == Invalid(non_empty_list.single(NotAFloat(".5")))
+}
+
+pub fn float_strict_rejects_trailing_dot_test() -> Nil {
+  assert parse.float_strict("3.", NotAFloat)
+    == Invalid(non_empty_list.single(NotAFloat("3.")))
+}
+
+pub fn float_strict_rejects_double_dot_test() -> Nil {
+  assert parse.float_strict("3.0.0", NotAFloat)
+    == Invalid(non_empty_list.single(NotAFloat("3.0.0")))
+}
+
+pub fn float_strict_rejects_whitespace_around_value_test() -> Nil {
+  // Strict parsing must not auto-trim; callers compose with
+  // `prep.trim()` if they want trim+strict.
+  assert parse.float_strict("  3.14  ", NotAFloat)
+    == Invalid(non_empty_list.single(NotAFloat("  3.14  ")))
+}
+
+pub fn float_strict_accepts_thousand_separator_period_test() -> Nil {
+  // "3.000" is unambiguously 3.0 in en_US locale and syntactically a
+  // valid float. The strict variant only catches structural
+  // garbage; locale ambiguity inside a syntactically-valid float
+  // cannot be resolved at this layer.
+  assert parse.float_strict("3.000", NotAFloat) == Valid(3.0)
+}
+
 // --- parse + validate pipeline ---
 
 pub fn int_then_validate_test() -> Nil {


### PR DESCRIPTION
## Summary

`dataprep/parse.float` delegates to `gleam/float.parse`, which is
lenient: it returns the parsed prefix when the input has trailing
non-numeric bytes. `parse.float(\"3,000\", ...)` returns `Valid(3.0)`
because parsing stops at the comma — silently coercing
locale-formatted thousand-separated values
(`de_DE` / `fr_FR` / `ja_JP` users typing `\"3,000\"` mean three
thousand) into a 1000× wrong amount.

`gleam/float.parse` is upstream and its lenient behaviour is unlikely
to change. dataprep's role is **input validation**, so add a strict
counterpart:

```gleam
parse.float_strict(\"3,000\", fn(s) { NotAFloat(s) })
// Invalid([NotAFloat(\"3,000\")])  -- not Valid(3.0)
```

## Changes

### `src/dataprep/parse.gleam`

- Add `parse.float_strict(raw: String, on_error: fn(String) -> e) -> Validated(Float, e)`.
- Validate the input against a strict-float grammar
  (`-?(\d+|\d+\.\d+)([eE]-?\d+)?`) before delegating to the existing
  `parse_lenient_float` to obtain the numeric value.
- Update the doc-comment on `parse.float` to flag the lenient /
  truncation footgun and point at `float_strict` for amount /
  address / quantity fields.
- Add `gleam/bool` and `gleam/regexp` imports.

### `test/dataprep/parse_test.gleam`

- Positive cases: `\"3.14\"`, `\"-1.5\"`, integer literal `\"5\"`,
  zero `\"0\"`, scientific `\"1.5e-2\"` / `\"5E3\"`, period
  thousand-style `\"3.000\"`.
- Negative cases: comma `\"3,000\"`, space `\"3 000\"`, trailing
  letters `\"12.50abc\"`, unit suffix `\"3K\"`, empty string,
  leading dot `\".5\"`, trailing dot `\"3.\"`, multiple dots
  `\"3.0.0\"`, surrounding whitespace `\"  3.14  \"`.

### `CHANGELOG.md`

- New entry under `[Unreleased]` describing the strict variant and
  the rejected input shapes.

## Design Decisions

**Why add `float_strict` rather than swap `float` to be strict.**
Issue #67 listed both options. Backward compatibility tipped the
balance: existing callers may rely on the lenient parse for
preprocessed inputs (e.g. CSV cells with trailing whitespace already
trimmed by `prep.trim`). Renaming `float` to `float_lenient` would be
a breaking change for every existing caller. Adding `float_strict`
lets callers opt into strictness one call site at a time.

**Why a regex grammar rather than \"reject if input contains comma\".**
The simpler reject-comma check would let `\"3K\"`, `\"12.50abc\"`,
`\"3 000\"` through. The regex grammar is one source of truth for
\"what the strict parser accepts\", which is the same as the documented
shapes in `parse.float`'s doc-comment minus partial-parse behaviour.

**Why `\"3.000\"` is accepted by the strict variant.** The issue noted
this is locale-ambiguous (en_US: 3.0; de_DE: three thousand). It is
also *syntactically* a valid float string — `\\d+\\.\\d+` matches.
Locale ambiguity inside a syntactically-valid float cannot be
resolved at this layer; callers needing locale-aware parsing should
do that upstream of `parse.float_strict`.

**Why surrounding whitespace is rejected by the strict variant.**
Strict means strict — callers compose with `prep.trim()` if they
want trim-then-strict. Auto-trimming inside the strict parser would
make the contract leaky.

## Test plan

- [x] `gleam test` — 374 passed (was 358; +16 new tests)
- [x] `just check` — format-check + glinter + check + build + test
- [x] Verified `\"3,000\"` rejection: `Invalid([NotAFloat(\"3,000\")])`
- [x] Verified backward compatibility: `parse.float(\"3,000\", ...) == Valid(3.0)` still holds

Closes #67.