### PR TITLE
chore(release): prepare v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-05-09
+
 ### Added
 
 - **`dataprep/parse`**: `parse.float_strict(raw, on_error)` is the

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "dataprep"
-version = "0.14.0"
+version = "0.15.0"
 description = "Composable, type-driven preprocessing and validation combinator library"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "dataprep" }


### PR DESCRIPTION
### Added

- **`dataprep/parse`**: `parse.float_strict(raw, on_error)` is the
  strict counterpart of `parse.float`. The lenient variant delegates
  to `gleam/float.parse`, which silently truncates inputs like
  `"3,000"` to `3.0` (parse stops at the comma) — a 1000× wrong
  amount for users typing locale-formatted thousand-separated values
  in `de_DE` / `fr_FR` / `ja_JP`. The strict variant validates the
  input with a strict-float grammar
  (`-?(\d+|\d+\.\d+)([eE]-?\d+)?`) and rejects anything else
  (commas, spaces, trailing letters, leading dots, multiple dots).
  `parse.float` keeps its lenient shape for backward compatibility,
  with an updated doc-comment that warns about the locale-truncation
  footgun and points at `float_strict` for amount fields. (#67)
- Property-based and metamorphic tests using
  [metamon](https://github.com/nao1215/metamon) covering the public
  surface of `dataprep/prep`, `dataprep/non_empty_list`, and
  `dataprep/validated`. Lives in `test/dataprep_metamon_test.gleam`.
  Highlights: `prep.then` is associative and `prep.identity` is a
  two-sided neutral; `prep.sequence([])` is the identity prep;
  `prep.trim` / `prep.lowercase` / `prep.uppercase` are idempotent;
  `prep.compose` is byte-equivalent to `prep.then`; `NonEmptyList`
  satisfies `length >= 1`, `to_list` / `from_list` round-trip,
  `reverse` is involutive and length-preserving, `append` lengths
  add, `head ∘ single == id`; `Validated.from_result` round-trips on
  both arms, `Valid` survives `map_error` / `Invalid` survives `map`,
  `map2` on two `Invalid`s concatenates errors, `sequence` and
  `traverse` agree on the all-`Valid` path.
