### PR TITLE
docs: add scope policy, cookbook, and out-of-scope sections to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- README now states the package's intentional **scope policy**: dataprep
+  is a combinator toolkit, not a rule catalog. Domain-specific parsers
+  (`email`, `url`, `uuid`, `iso_datetime`, `ipv4`, ...) are explicitly
+  out of scope, with rationale. This surfaces the design statement
+  previously documented only in `CLAUDE.md`. (#71)
+- README adds a **"Building your own parser" cookbook** with four
+  recipes (`positive_int`, `bounded_string`, `uuid_v4_lowercase`,
+  `enum_of_strings_ci`) showing how `prep` + `rules` + `validator` +
+  `parse` compose into the parsers callers commonly want. Every
+  recipe is verified by the new `test/dataprep/cookbook_test.gleam`
+  test module so future API changes will surface as test failures
+  rather than stale docs. (#71)
+- README adds a **"Out of scope, by design"** list naming
+  `email`/`url`/`uri`, `iso_datetime`/time, `uuid`/`ulid`, JSON
+  shape validation, and HTML/XML sanitisation as the categories
+  the package will not absorb, with a one-line "why" per category. (#71)
+- Modules table: `parse` now lists `float_strict` alongside `int` and
+  `float`. The function existed in 0.15.0 but was missing from the
+  table. (#71)
+
 ## [0.15.0] - 2026-05-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -436,8 +436,8 @@ fn uuid_v4_lowercase(raw: String) -> Validated(String, Err) {
       prep: prep.then(first: prep.trim(), next: prep.lowercase()),
       value: raw,
     )
-  rules.matches_string(
-    pattern: "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+  rules.matches_fully_string(
+    pattern: "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}",
     error: NotUuid(raw),
   )(normalized)
 }

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ More examples are available in the [doc/recipes/](https://github.com/nao1215/dat
 | `dataprep/validated` | Applicative error accumulation: `map`, `map_error`, `and_then`, `from_result`, `from_result_map`, `to_result`, `map2`..`map5`, `sequence`, `traverse`, `traverse_indexed`. |
 | `dataprep/non_empty_list` | At-least-one guarantee for error lists: `single`, `cons`, `append`, `concat`, `map`, `flat_map`, `to_list`, `from_list`. |
 | `dataprep/rules` | Built-in rules: `not_empty`, `not_blank`, `matches`, `matches_string`, `matches_string_checked`, `matches_fully`, `matches_fully_string`, `matches_fully_string_checked`, `min_length`, `max_length`, `length_between`, `min_int`, `max_int`, `min_float`, `max_float`, `non_negative_int`, `non_negative_float`, `one_of`, `equals`. |
-| `dataprep/parse` | Parse helpers: `int`, `float`. Bridge `String` to typed `Validated` with custom error mapping. |
+| `dataprep/parse` | Parse helpers: `int`, `float`, `float_strict`. Bridge `String` to typed `Validated` with custom error mapping. |
 
 ## Composition overview
 
@@ -341,6 +341,148 @@ More examples are available in the [doc/recipes/](https://github.com/nao1215/dat
 | Collection | `validated.sequence` / `traverse` | Accumulate all | Validate a list of values |
 | Collection | `validator.each` | Accumulate all | Apply a validator to every list element |
 | Collection | `validator.optional` | (none if None) | Skip validation for absent values |
+
+## Scope policy
+
+dataprep is a **combinator toolkit**, not a rule catalog. The library
+deliberately ships only the building blocks needed to construct
+typed, error-accumulating validators:
+
+- infallible string transforms (`prep`),
+- generic checks (`validator`, `rules`),
+- applicative error accumulation (`validated`, `non_empty_list`),
+- `String` to `Int` / `Float` parsers (`parse`).
+
+Domain-specific parsers (`email`, `url`, `uuid`, `iso_datetime`,
+`ipv4`, ...) are intentionally **not in scope**. The recommended
+path is to compose the primitives above into the parser you need,
+or to depend on a domain-specific package alongside dataprep.
+
+See "Building your own parser" below for the recipes.
+
+## Building your own parser
+
+The recipes below cover the common shapes a caller actually wants.
+Each recipe uses only the public API and is verified by the tests in
+`test/dataprep/cookbook_test.gleam`.
+
+The recipes share one error type so they can be combined inside the
+same form-validation flow:
+
+```gleam
+pub type Err {
+  NotAnInteger(raw: String)
+  NotPositive
+  WrongLength(min: Int, max: Int, got: Int)
+  NotUuid(raw: String)
+  NotAllowed(raw: String)
+}
+```
+
+### Recipe 1: `positive_int`
+
+Parse to `Int`, then enforce `> 0`. Uses `validated.and_then` to
+short-circuit when the parse itself fails.
+
+```gleam
+import dataprep/parse
+import dataprep/validated.{type Validated}
+import dataprep/validator
+
+fn positive_int(raw: String) -> Validated(Int, Err) {
+  use n <- validated.and_then(parse.int(raw, NotAnInteger))
+  validator.predicate(fn(x) { x > 0 }, NotPositive)(n)
+}
+```
+
+### Recipe 2: `bounded_string`
+
+Trim, then enforce length is in `[min, max]`.
+
+```gleam
+import dataprep/prep
+import dataprep/rules
+import dataprep/validated.{type Validated}
+import gleam/string
+
+fn bounded_string(
+  min: Int,
+  max: Int,
+) -> fn(String) -> Validated(String, Err) {
+  fn(raw: String) {
+    let trimmed = prep.run(prep: prep.trim(), value: raw)
+    rules.length_between(
+      minimum: min,
+      maximum: max,
+      error: WrongLength(min, max, string.length(trimmed)),
+    )(trimmed)
+  }
+}
+```
+
+### Recipe 3: `uuid_v4_lowercase`
+
+Trim, lowercase, then regex match. Demonstrates `prep.then` for
+chained infallible normalisation before validation.
+
+```gleam
+import dataprep/prep
+import dataprep/rules
+import dataprep/validated.{type Validated}
+
+fn uuid_v4_lowercase(raw: String) -> Validated(String, Err) {
+  let normalized =
+    prep.run(
+      prep: prep.then(first: prep.trim(), next: prep.lowercase()),
+      value: raw,
+    )
+  rules.matches_string(
+    pattern: "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+    error: NotUuid(raw),
+  )(normalized)
+}
+```
+
+### Recipe 4: `enum_of_strings_ci`
+
+Case-insensitive match against a fixed allow-list. Returns a
+parameterised validator so callers can vary the allowed set.
+
+```gleam
+import dataprep/prep
+import dataprep/rules
+import dataprep/validated.{type Validated}
+
+fn enum_of_strings_ci(
+  allowed: List(String),
+) -> fn(String) -> Validated(String, Err) {
+  fn(raw: String) {
+    let normalized = prep.run(prep: prep.lowercase(), value: raw)
+    rules.one_of(allowed: allowed, error: NotAllowed(raw))(normalized)
+  }
+}
+```
+
+The composition pattern is the same in every case: `prep.run` to
+normalise the raw input, then a `rules` or `validator` combinator
+to check the normalised value, then optionally `validated.and_then`
+to chain a follow-up step that depends on a successful prior step.
+
+## Out of scope, by design
+
+The following are intentionally not provided by dataprep, even
+though some of them appear in adjacent libraries in other languages:
+
+- `email`, `url`, `uri` parsing (use a URI- or email-specific package)
+- `iso_datetime` / time arithmetic (use a `gleam_time`-shaped package)
+- `uuid` / `ulid` generation (use a UUID-shaped package)
+- JSON shape validation (use a JSON-schema package)
+- HTML / XML sanitisation (use a sanitiser package)
+
+These have implementation-defining standards or substantial spec
+surface that would push dataprep from "small primitives" toward
+"kitchen sink." Keeping the scope tight is what lets the
+combinators stay composable.
 
 ## Development
 

--- a/test/dataprep/cookbook_test.gleam
+++ b/test/dataprep/cookbook_test.gleam
@@ -76,8 +76,8 @@ fn uuid_v4_lowercase(raw: String) -> Validated(String, Err) {
       prep: prep.then(first: prep.trim(), next: prep.lowercase()),
       value: raw,
     )
-  rules.matches_string(
-    pattern: "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+  rules.matches_fully_string(
+    pattern: "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}",
     error: NotUuid(raw),
   )(normalized)
 }

--- a/test/dataprep/cookbook_test.gleam
+++ b/test/dataprep/cookbook_test.gleam
@@ -1,0 +1,123 @@
+//// Verifies that the recipes documented in README's "Building your own
+//// parser" section compile and behave as advertised. Each recipe is a
+//// composition of `prep` / `rules` / `validator` / `parse` primitives —
+//// no new dataprep functionality is introduced here.
+
+import dataprep/non_empty_list
+import dataprep/parse
+import dataprep/prep
+import dataprep/rules
+import dataprep/validated.{type Validated, Invalid, Valid}
+import dataprep/validator
+import gleam/string
+
+pub type Err {
+  NotAnInteger(raw: String)
+  NotPositive
+  WrongLength(min: Int, max: Int, got: Int)
+  NotUuid(raw: String)
+  NotAllowed(raw: String)
+}
+
+// --- Recipe 1: positive_int ---
+// Parse to Int, then enforce > 0.
+
+fn positive_int(raw: String) -> Validated(Int, Err) {
+  use n <- validated.and_then(parse.int(raw, NotAnInteger))
+  validator.predicate(fn(x) { x > 0 }, NotPositive)(n)
+}
+
+pub fn cookbook_positive_int_pass_test() -> Nil {
+  assert positive_int("42") == Valid(42)
+}
+
+pub fn cookbook_positive_int_zero_rejected_test() -> Nil {
+  assert positive_int("0") == Invalid(non_empty_list.single(NotPositive))
+}
+
+pub fn cookbook_positive_int_negative_rejected_test() -> Nil {
+  assert positive_int("-1") == Invalid(non_empty_list.single(NotPositive))
+}
+
+pub fn cookbook_positive_int_not_a_number_test() -> Nil {
+  assert positive_int("abc")
+    == Invalid(non_empty_list.single(NotAnInteger("abc")))
+}
+
+// --- Recipe 2: bounded_string ---
+// Trim, then enforce length is in [min, max].
+
+fn bounded_string(min: Int, max: Int) -> fn(String) -> Validated(String, Err) {
+  fn(raw: String) {
+    let trimmed = prep.run(prep: prep.trim(), value: raw)
+    rules.length_between(
+      minimum: min,
+      maximum: max,
+      error: WrongLength(min, max, string.length(trimmed)),
+    )(trimmed)
+  }
+}
+
+pub fn cookbook_bounded_string_in_range_test() -> Nil {
+  assert bounded_string(3, 10)("  hello  ") == Valid("hello")
+}
+
+pub fn cookbook_bounded_string_too_short_test() -> Nil {
+  assert bounded_string(5, 10)("hi")
+    == Invalid(non_empty_list.single(WrongLength(5, 10, 2)))
+}
+
+// --- Recipe 3: uuid_v4_lowercase ---
+// Trim + lowercase + regex match.
+
+fn uuid_v4_lowercase(raw: String) -> Validated(String, Err) {
+  let normalized =
+    prep.run(
+      prep: prep.then(first: prep.trim(), next: prep.lowercase()),
+      value: raw,
+    )
+  rules.matches_string(
+    pattern: "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+    error: NotUuid(raw),
+  )(normalized)
+}
+
+pub fn cookbook_uuid_lowercase_pass_test() -> Nil {
+  assert uuid_v4_lowercase("550e8400-e29b-41d4-a716-446655440000")
+    == Valid("550e8400-e29b-41d4-a716-446655440000")
+}
+
+pub fn cookbook_uuid_uppercase_normalized_test() -> Nil {
+  // Uppercase input is normalised to lowercase before matching.
+  assert uuid_v4_lowercase("550E8400-E29B-41D4-A716-446655440000")
+    == Valid("550e8400-e29b-41d4-a716-446655440000")
+}
+
+pub fn cookbook_uuid_v1_rejected_test() -> Nil {
+  // Version digit other than 4 is rejected.
+  let raw = "550e8400-e29b-11d4-a716-446655440000"
+  assert uuid_v4_lowercase(raw) == Invalid(non_empty_list.single(NotUuid(raw)))
+}
+
+// --- Recipe 4: enum_of_strings_ci ---
+// Lowercase, then one_of allowed.
+
+fn enum_of_strings_ci(
+  allowed: List(String),
+) -> fn(String) -> Validated(String, Err) {
+  fn(raw: String) {
+    let normalized = prep.run(prep: prep.lowercase(), value: raw)
+    rules.one_of(allowed: allowed, error: NotAllowed(raw))(normalized)
+  }
+}
+
+pub fn cookbook_enum_ci_match_test() -> Nil {
+  let level_validator = enum_of_strings_ci(["debug", "info", "warn", "error"])
+  assert level_validator("INFO") == Valid("info")
+}
+
+pub fn cookbook_enum_ci_no_match_test() -> Nil {
+  let level_validator = enum_of_strings_ci(["debug", "info", "warn", "error"])
+  assert level_validator("trace")
+    == Invalid(non_empty_list.single(NotAllowed("trace")))
+}


### PR DESCRIPTION
## Summary

Surfaces the intentional **thin combinator toolkit** design policy
(previously documented only in `CLAUDE.md`) into the README, and adds
worked recipes showing how to compose the existing primitives into
common domain parsers.

## Changes

- New **Scope policy** section after Composition overview — states
  what dataprep ships and that domain-specific parsers (email, url,
  uuid, iso_datetime, ipv4, ...) are intentionally out of scope.
- New **Building your own parser** cookbook with 4 recipes:
  - \`positive_int\` — parse-then-validate
  - \`bounded_string\` — prep + rule
  - \`uuid_v4_lowercase\` — multi-step prep + regex match
  - \`enum_of_strings_ci\` — parameterised case-insensitive validator
- New **Out of scope, by design** list naming the categories the
  package will not absorb, with a one-line rationale per category.
- Modules table fix: \`parse\` now lists \`float_strict\` alongside
  \`int\` and \`float\` (the function existed but was undocumented in
  the table).
- New \`test/dataprep/cookbook_test.gleam\` (11 tests) verifies every
  recipe compiles and behaves as the README claims. This is the
  pesticide-paradox antidote suggested in the issue: future API
  changes that break a recipe will surface as a test failure rather
  than as stale documentation.

## Design decisions

- **Single shared \`Err\` type for all recipes**. The cookbook''s
  recipes all use one \`Err\` type with multiple variants. This
  matches the existing test style (\`test/dataprep/parse_test.gleam\`)
  where each test module defines a domain \`Err\` enum and uses
  constructors directly as the \`on_error\` argument. Avoids
  redefining the error type per recipe and demonstrates how callers
  compose multiple recipes inside the same form-validation flow.
- **Cookbook test file kept rather than deleted after verification**.
  Initially considered removing the test after confirming the recipes
  compile, but keeping it provides regression resistance — if a
  future API change breaks a recipe, the test fails loudly rather
  than the docs going stale silently.
- **Recipes return parameterised validators where parameters vary**
  (\`bounded_string(min, max)\`, \`enum_of_strings_ci(allowed)\`) and
  return \`Validated\` directly where they don''t (\`positive_int\`,
  \`uuid_v4_lowercase\`). This matches existing combinator style.
- **No source code changes**. The recipes use only the existing
  public API. The package surface is unchanged.

## Verification

- \`just check\` passes (385 tests, including 11 new cookbook tests).
- gleam format clean, glinter clean, type-checks, builds with
  \`--warnings-as-errors\`.

Closes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation with a scope policy clarifying dataprep's boundaries and intentional design decisions.
  * Added "Building your own parser" section with four concrete recipe examples demonstrating parser composition.
  * Updated module table to include `float_strict` reference.

* **Tests**
  * Added comprehensive tests verifying the cookbook recipe examples.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/dataprep/pull/72)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->