### PR TITLE
fix(parse): accept '+' on exponent in float_strict scientific notation (#74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `parse.float_strict` now accepts standard scientific notation with an
+  explicit `+` sign on the exponent (e.g. `"1.5e+2"`, `"5e+3"`,
+  `"1.5E+10"`). Previously the strict-grammar regex only allowed an
+  optional `-` on the exponent, so inputs that the lenient `parse.float`
+  accepted — and that every standard float grammar (IEEE 754,
+  ECMAScript, Python, Rust, Go) accepts — were incorrectly rejected.
+  This restores the documented invariant that strict is a subset of
+  lenient. (#74)
+
 ## [0.16.0] - 2026-05-11
 
 ### Documentation

--- a/src/dataprep/parse.gleam
+++ b/src/dataprep/parse.gleam
@@ -94,7 +94,7 @@ pub fn float_strict(
 fn strict_float_grammar_matches(raw: String) -> Bool {
   // nolint: assert_ok_pattern -- the strict-float regex is a fixed, known-valid literal
   let assert Ok(strict_re) =
-    regexp.from_string("^-?(?:\\d+\\.\\d+|\\d+)(?:[eE]-?\\d+)?$")
+    regexp.from_string("^-?(?:\\d+\\.\\d+|\\d+)(?:[eE][+-]?\\d+)?$")
   regexp.check(with: strict_re, content: raw)
 }
 

--- a/test/dataprep/parse_test.gleam
+++ b/test/dataprep/parse_test.gleam
@@ -137,6 +137,21 @@ pub fn float_strict_scientific_uppercase_test() -> Nil {
   assert parse.float_strict("5E3", NotAFloat) == Valid(5000.0)
 }
 
+pub fn float_strict_scientific_explicit_plus_exponent_test() -> Nil {
+  // Standard scientific notation (IEEE 754, ECMAScript, Python, Rust, Go)
+  // accepts a leading `+` on the exponent. Strict must accept what lenient
+  // accepts -- the docstring guarantees strict is a subset of lenient. (#74)
+  assert parse.float_strict("1.5e+2", NotAFloat) == Valid(150.0)
+}
+
+pub fn float_strict_scientific_explicit_plus_exponent_integer_mantissa_test() -> Nil {
+  assert parse.float_strict("5e+3", NotAFloat) == Valid(5000.0)
+}
+
+pub fn float_strict_scientific_explicit_plus_exponent_uppercase_test() -> Nil {
+  assert parse.float_strict("1.5E+10", NotAFloat) == Valid(15_000_000_000.0)
+}
+
 pub fn float_strict_rejects_thousand_separator_comma_test() -> Nil {
   // The whole point of float_strict: lenient parse silently returns
   // 3.0 here; strict must reject so locale-formatted thousand


### PR DESCRIPTION
## Summary

Closes #74.

`parse.float_strict` was rejecting standard scientific-notation inputs whose exponent carries an explicit `+` sign (e.g. `"1.5e+2"`, `"5e+3"`, `"1.5E+10"`). Every standard float grammar — IEEE 754, ECMAScript §7.1.4.1.1, Python `float()`, Rust `f64::from_str`, Go — accepts a leading `+` on the exponent, and the lenient sibling `parse.float` already accepted these inputs. The strict path's docstring guarantees it is a subset of lenient, so the asymmetry was a bug, not a deliberate restriction.

## Changes

- `src/dataprep/parse.gleam`: change the strict-float regex exponent group from `[eE]-?\d+` to `[eE][+-]?\d+`, so the optional sign matches the standard scientific-notation grammar.
- `test/dataprep/parse_test.gleam`: add three regression tests covering the bug's reported inputs (lowercase `e+`, integer mantissa with `e+`, uppercase `E+` with a large exponent).
- `CHANGELOG.md`: `[Unreleased]` → `### Fixed` entry citing #74.

The fix is localised to one regex character class — the surrounding strict-grammar guarantees (no leading dot, no trailing dot, no thousand separators, no whitespace) are preserved verbatim.

## Test plan

- [x] `just check` passes (format, glinter, gleam check, build with warnings-as-errors, full test suite — 388 tests, 0 failures, including the 3 new regressions)
- [x] Bug reproduction from the issue body now returns `Valid(150.0)` for `"1.5e+2"` (verified through the new `float_strict_scientific_explicit_plus_exponent_test`)
- [x] All pre-existing `float_strict` rejection cases (thousand separator, whitespace, leading/trailing dot, etc.) still pass — the regex change only widens the exponent sign, not the mantissa or surrounding grammar
