### PR TITLE
chore(release): prepare v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-05-10
+
 ### Fixed
 
 - `parse.float_strict` now accepts standard scientific notation with an

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "dataprep"
-version = "0.16.0"
+version = "0.17.0"
 description = "Composable, type-driven preprocessing and validation combinator library"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "dataprep" }


### PR DESCRIPTION
### Fixed

- `parse.float_strict` now accepts standard scientific notation with an
  explicit `+` sign on the exponent (e.g. `"1.5e+2"`, `"5e+3"`,
  `"1.5E+10"`). Previously the strict-grammar regex only allowed an
  optional `-` on the exponent, so inputs that the lenient `parse.float`
  accepted — and that every standard float grammar (IEEE 754,
  ECMAScript, Python, Rust, Go) accepts — were incorrectly rejected.
  This restores the documented invariant that strict is a subset of
  lenient. (#74)
