### PR TITLE
fix(parse): guard parse.float against plain-digit IEEE 754 overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `parse.float` and `parse.float_strict` no longer panic with Erlang
+  `badarg` on plain-digit inputs whose magnitude exceeds the IEEE 754
+  double range (e.g. `"9"` repeated 309 times, or any decimal integer
+  literal with more than 308 digits). Previously the call to
+  `gleam/int.to_float` invoked the BEAM's `erlang:float/1` BIF, which
+  raised at the runtime level and crashed the calling actor or HTTP
+  handler. The function now funnels the overflow into the documented
+  `Invalid` shape that its `Validated(Float, e)` return type already
+  promises, consistently with the scientific-notation overflow path
+  fixed in #77. (#80)
+
 ## [0.18.0] - 2026-05-11
 
 ### Fixed

--- a/src/dataprep/parse.gleam
+++ b/src/dataprep/parse.gleam
@@ -6,6 +6,7 @@ import dataprep/validated.{type Validated, Invalid, Valid}
 import gleam/bool
 import gleam/float
 import gleam/int
+import gleam/list
 import gleam/regexp
 import gleam/result
 import gleam/string
@@ -110,11 +111,26 @@ fn parse_lenient_float(raw: String) -> Result(Float, Nil) {
     when: has_overflowing_scientific_exponent(raw),
     return: Error(Nil),
   )
+  // Plain-integer literals (no decimal point, no `e`) with more than
+  // 308 significant digits overflow IEEE 754 doubles. On Erlang
+  // `int.to_float` -> `erlang:float/1` raises `badarg`; on JavaScript
+  // `parseInt` already returns `Infinity` (Gleam's `Int` on JS is a
+  // `Number`, not a `BigInt`). Both targets need to funnel this case
+  // into `Invalid`, so we guard on the raw string before either parser
+  // sees it. (#80)
+  use <- bool.guard(
+    when: has_overflowing_plain_integer_literal(raw),
+    return: Error(Nil),
+  )
   case float.parse(raw) {
     Ok(x) -> Ok(x)
     Error(Nil) ->
       case int.parse(raw) {
-        Ok(n) -> Ok(int.to_float(n))
+        Ok(n) ->
+          case has_overflowing_integer_magnitude(n) {
+            True -> Error(Nil)
+            False -> Ok(int.to_float(n))
+          }
         Error(Nil) -> parse_scientific(raw)
       }
   }
@@ -136,6 +152,29 @@ fn has_overflowing_scientific_exponent(raw: String) -> Bool {
         Error(Nil) -> False
       }
     }
+  }
+}
+
+fn has_overflowing_integer_magnitude(n: Int) -> Bool {
+  int.absolute_value(n)
+  |> int.to_string
+  |> string.length
+  > 308
+}
+
+fn has_overflowing_plain_integer_literal(raw: String) -> Bool {
+  let digits = case string.starts_with(raw, "-") {
+    True -> string.drop_start(raw, 1)
+    False -> raw
+  }
+  string.length(digits) > 308
+  && list.all(string.to_graphemes(digits), is_ascii_digit_grapheme)
+}
+
+fn is_ascii_digit_grapheme(g: String) -> Bool {
+  case g {
+    "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" -> True
+    _ -> False
   }
 }
 

--- a/test/dataprep/parse_test.gleam
+++ b/test/dataprep/parse_test.gleam
@@ -3,6 +3,7 @@ import dataprep/parse
 import dataprep/rules
 import dataprep/validated.{Invalid, Valid}
 import dataprep/validator
+import gleam/string
 
 type Err {
   NotAnInteger(raw: String)
@@ -148,6 +149,39 @@ pub fn float_preserves_underflow_to_zero_test() -> Nil {
 pub fn float_strict_rejects_overflow_exponent_test() -> Nil {
   assert parse.float_strict("1e309", NotAFloat)
     == Invalid(non_empty_list.single(NotAFloat("1e309")))
+}
+
+// --- parse.float plain-integer overflow (#80) ---
+
+pub fn float_accepts_long_digit_at_upper_boundary_test() -> Nil {
+  let raw = string.repeat("9", 308)
+  // nolint: assert_ok_pattern -- a 308-digit integer literal stays within the IEEE 754 range
+  let assert Valid(_) = parse.float(raw, NotAFloat)
+  Nil
+}
+
+pub fn float_rejects_long_digit_overflow_test() -> Nil {
+  let raw = string.repeat("9", 309)
+  assert parse.float(raw, NotAFloat)
+    == Invalid(non_empty_list.single(NotAFloat(raw)))
+}
+
+pub fn float_rejects_far_overflow_long_digit_test() -> Nil {
+  let raw = string.repeat("9", 1000)
+  assert parse.float(raw, NotAFloat)
+    == Invalid(non_empty_list.single(NotAFloat(raw)))
+}
+
+pub fn float_rejects_negative_long_digit_overflow_test() -> Nil {
+  let raw = "-" <> string.repeat("9", 309)
+  assert parse.float(raw, NotAFloat)
+    == Invalid(non_empty_list.single(NotAFloat(raw)))
+}
+
+pub fn float_strict_rejects_long_digit_overflow_test() -> Nil {
+  let raw = string.repeat("9", 309)
+  assert parse.float_strict(raw, NotAFloat)
+    == Invalid(non_empty_list.single(NotAFloat(raw)))
 }
 
 // --- parse.float_strict (#67) ---


### PR DESCRIPTION
## Summary

`dataprep/parse.float` and `parse.float_strict` previously crashed with Erlang `badarg` on plain-digit inputs whose magnitude exceeds the IEEE 754 double range (e.g. `"9"` repeated 309 times). The signatures return `Validated(Float, e)`, so they must never panic for any `String` — this fix funnels the overflow into `Invalid` consistently with the scientific-notation overflow path fixed in #77.

## Changes

- `src/dataprep/parse.gleam` — added a raw-string pre-guard on `parse_lenient_float` that rejects digit-only inputs whose digit count exceeds 308. Also added `has_overflowing_integer_magnitude/1` as a backstop on the `int.parse(raw) -> int.to_float(n)` branch to avoid the `erlang:float/1` BIF crashing for Erlang-target inputs.
- `test/dataprep/parse_test.gleam` — 5 new tests covering the 308-digit upper boundary (`Valid`), 309-digit overflow, 1000-digit far overflow, negative form, and `parse.float_strict` parity.
- `CHANGELOG.md` — `## [Unreleased]` `### Fixed` entry.

## Design Decisions

- **Pre-guard on the raw string, not on the parsed `Int`.** On the JavaScript target `gleam/int` is backed by `Number`, so `int.parse(\"9\".repeat(309))` already returns `Ok(Infinity)` and the digit-count-of-`int.to_string` magnitude check is useless. Checking the raw input first keeps both targets honest with the same `Invalid` contract.
- **Backstop on the `Int` branch is kept for Erlang.** Belt-and-braces: even if the pre-guard ever misses (e.g. future grammar expansion), `has_overflowing_integer_magnitude` prevents `int.to_float` from ever seeing an out-of-range value on BEAM.
- **Boundary at 308 digits.** 308 nines ≈ 9.99e307 < 1.7976931348623157e308 (IEEE 754 max), so 308 digits stays in range and 309 digits is guaranteed out — matches the `exp > 308` boundary used by `has_overflowing_scientific_exponent` from #77.
- **No new constants.** The 308 threshold is small and self-documenting in context; an `f64_max` literal would invite the very `Int×Float` comparison we are trying to avoid.

## Testing

- `mise exec -- just ci` — pass (format-check, glinter, typecheck, build --warnings-as-errors, test).
- `mise exec -- gleam test --target erlang` — 399 passed.
- `mise exec -- gleam test --target javascript` — 399 passed.

## Limitations

None known. The fix preserves all existing accepting cases (verified by the 308-digit boundary test and the unchanged scientific-notation overflow tests from #77).

Closes #80