### PR TITLE
chore(release): prepare v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-05-11
+
 ### Fixed
 
 - `parse.float` and `parse.float_strict` no longer panic with Erlang

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "dataprep"
-version = "0.18.0"
+version = "0.19.0"
 description = "Composable, type-driven preprocessing and validation combinator library"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "dataprep" }


### PR DESCRIPTION
### Fixed

- `parse.float` and `parse.float_strict` no longer panic with Erlang
  `badarg` on plain-digit inputs whose magnitude exceeds the IEEE 754
  double range (e.g. `"9"` repeated 309 times, or any decimal integer
  literal with more than 308 digits). Previously the call to
  `gleam/int.to_float` invoked the BEAM's `erlang:float/1` BIF, which
  raised at the runtime level and crashed the calling actor or HTTP
  handler. The function now funnels the overflow into the documented
  `Invalid` shape that its `Validated(Float, e)` return type already
  promises, consistently with the scientific-notation overflow path
  fixed in #77. (#80)
