### PR TITLE
feat(validated): add pipe-friendly combine2..combine5 aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `validated.combine2`, `combine3`, `combine4`, `combine5`:
+  pipe-friendly aliases of `map2..map5` that take the `Validated`
+  receivers first and the combining function last via the `with`
+  label. The applicative `mapN` form (function-first, mirroring
+  Haskell-style `f <$> va <*> vb <*> ...`) stays for callers who
+  prefer it, but multi-field validators built on this module can
+  now flow through a single pipe — `validate_a(x) |>
+  validated.combine4(validate_b(y), validate_c(z), validate_d(w),
+  with: fn(a, b, c, d) { ... })`. (#83)
+
 ## [0.19.0] - 2026-05-11
 
 ### Fixed

--- a/src/dataprep/validated.gleam
+++ b/src/dataprep/validated.gleam
@@ -135,6 +135,58 @@ pub fn map5(
   )
 }
 
+/// Pipe-friendly form of [map2](#map2): takes the receivers first and
+/// the combining function last via the `with` label, so the first
+/// `Validated` can flow in through a pipe.
+///
+/// Equivalent to `map2(f, va, vb)`.
+///
+/// Example:
+///   validate_object(d.object)
+///   |> validated.combine2(validate_seeing(d.seeing), with: fn(o, s) {
+///     #(o, s)
+///   })
+pub fn combine2(
+  va: Validated(a, e),
+  vb: Validated(b, e),
+  with f: fn(a, b) -> c,
+) -> Validated(c, e) {
+  map2(f, va, vb)
+}
+
+/// Pipe-friendly form of [map3](#map3). See [combine2](#combine2).
+pub fn combine3(
+  va: Validated(a, e),
+  vb: Validated(b, e),
+  vc: Validated(c, e),
+  with f: fn(a, b, c) -> d,
+) -> Validated(d, e) {
+  map3(f, va, vb, vc)
+}
+
+/// Pipe-friendly form of [map4](#map4). See [combine2](#combine2).
+pub fn combine4(
+  va: Validated(a, e),
+  vb: Validated(b, e),
+  vc: Validated(c, e),
+  vd: Validated(d, e),
+  with f: fn(a, b, c, d) -> out,
+) -> Validated(out, e) {
+  map4(f, va, vb, vc, vd)
+}
+
+/// Pipe-friendly form of [map5](#map5). See [combine2](#combine2).
+pub fn combine5(
+  va: Validated(a, e),
+  vb: Validated(b, e),
+  vc: Validated(c, e),
+  vd: Validated(d, e),
+  ve: Validated(e_, e),
+  with f: fn(a, b, c, d, e_) -> out,
+) -> Validated(out, e) {
+  map5(f, va, vb, vc, vd, ve)
+}
+
 /// Combine a list of Validated values into a Validated list.
 /// All errors from all elements are accumulated.
 /// Returns Valid([]) for an empty input list.

--- a/test/dataprep/validated_test.gleam
+++ b/test/dataprep/validated_test.gleam
@@ -334,3 +334,70 @@ pub fn map3_error_order_test() -> Nil {
     )
     == Invalid(nel.make(first: "a", rest: ["b", "c"]))
 }
+
+// --- combine2..combine5 (pipe-friendly aliases for map2..map5) ---
+
+pub fn combine2_pipes_first_validated_test() -> Nil {
+  assert Valid(1)
+    |> validated.combine2(Valid(2), with: fn(a, b) { a + b })
+    == Valid(3)
+}
+
+pub fn combine2_accumulates_errors_test() -> Nil {
+  assert Invalid(non_empty_list.single("a"))
+    |> validated.combine2(Invalid(non_empty_list.single("b")), with: fn(_, _) {
+      Nil
+    })
+    == Invalid(nel.make(first: "a", rest: ["b"]))
+}
+
+pub fn combine3_pipes_first_validated_test() -> Nil {
+  assert Valid(1)
+    |> validated.combine3(Valid(2), Valid(3), with: Triple)
+    == Valid(Triple(1, 2, 3))
+}
+
+pub fn combine3_accumulates_errors_test() -> Nil {
+  assert Invalid(non_empty_list.single("a"))
+    |> validated.combine3(
+      Valid(2),
+      Invalid(non_empty_list.single("c")),
+      with: Triple,
+    )
+    == Invalid(nel.make(first: "a", rest: ["c"]))
+}
+
+pub fn combine4_pipes_first_validated_test() -> Nil {
+  assert Valid(1)
+    |> validated.combine4(Valid(2), Valid(3), Valid(4), with: Quad)
+    == Valid(Quad(1, 2, 3, 4))
+}
+
+pub fn combine4_accumulates_errors_test() -> Nil {
+  assert Invalid(non_empty_list.single("a"))
+    |> validated.combine4(
+      Invalid(non_empty_list.single("b")),
+      Valid(3),
+      Invalid(non_empty_list.single("d")),
+      with: Quad,
+    )
+    == Invalid(nel.make(first: "a", rest: ["b", "d"]))
+}
+
+pub fn combine5_pipes_first_validated_test() -> Nil {
+  assert Valid(1)
+    |> validated.combine5(Valid(2), Valid(3), Valid(4), Valid(5), with: Quint)
+    == Valid(Quint(1, 2, 3, 4, 5))
+}
+
+pub fn combine5_accumulates_errors_test() -> Nil {
+  assert Invalid(non_empty_list.single("a"))
+    |> validated.combine5(
+      Valid(2),
+      Invalid(non_empty_list.single("c")),
+      Valid(4),
+      Invalid(non_empty_list.single("e")),
+      with: Quint,
+    )
+    == Invalid(nel.make(first: "a", rest: ["c", "e"]))
+}


### PR DESCRIPTION
## Summary

Fixes #83 — `validated.map2..map5` take the combining function as the first argument so callers can write the applicative shape `f <$> va <*> vb <*> ...`, but that breaks the pipe chain because the first arg can't be a `Validated` receiver.

## Approach

Adds pipe-friendly aliases `combine2..combine5` that mirror the same semantics as `map2..map5` but flip the argument order to receivers-first and accept the combining function through a `with` label:

```gleam
validate_object(d.object)
|> validated.combine4(
  validate_seeing(d.seeing),
  validate_lat(d.latitude),
  validate_lng(d.longitude),
  with: fn(obj, see, lat, lng) { DraftSession(obj, see, lat, lng, ...) },
)
```

`mapN` stays unchanged for callers who prefer the applicative shape (Option 1 from the issue — additive, no breaking changes).

## Changes

- `src/dataprep/validated.gleam`: add `combine2`, `combine3`, `combine4`, `combine5`, each delegating to its `mapN` counterpart.
- `test/dataprep/validated_test.gleam`: add Valid-path and error-accumulation tests for each new function.
- `CHANGELOG.md`: note the addition under `[Unreleased]`.

## Test plan

- `gleam test` — 407 passed, no failures.
- `gleam format --check .`, `gleam run -m glinter`, `gleam check` all clean.

Closes #83
