### PR TITLE
chore(release): prepare v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-05-12
+
 ### Added
 
 - `validated.combine2`, `combine3`, `combine4`, `combine5`:

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "dataprep"
-version = "0.19.0"
+version = "0.20.0"
 description = "Composable, type-driven preprocessing and validation combinator library"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "dataprep" }


### PR DESCRIPTION
### Added

- `validated.combine2`, `combine3`, `combine4`, `combine5`:
  pipe-friendly aliases of `map2..map5` that take the `Validated`
  receivers first and the combining function last via the `with`
  label. The applicative `mapN` form (function-first, mirroring
  Haskell-style `f <$> va <*> vb <*> ...`) stays for callers who
  prefer it, but multi-field validators built on this module can
  now flow through a single pipe — `validate_a(x) |>
  validated.combine4(validate_b(y), validate_c(z), validate_d(w),
  with: fn(a, b, c, d) { ... })`. (#83)
