### PR TITLE
feat(validator): add also alias for both to ease longer chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `dataprep/validator`: `validator.also/2` as a pipe-friendly alias of `validator.both/2` for chains of three or more error-accumulating checks. Reads as "this check also has to pass" at every step, instead of `both` (which implies two things). Identical semantics — both functions accumulate errors the same way — so the choice is purely stylistic. The `both/2` doc-comment now also points readers at `validator.all([...])` for the list form once chains grow beyond a handful of checks. (#87)
+
 ## [0.20.0] - 2026-05-12
 
 ### Added

--- a/src/dataprep/validator.gleam
+++ b/src/dataprep/validator.gleam
@@ -69,6 +69,14 @@ pub fn required(error: e) -> Validator(String, e) {
 
 /// Run both validators on the same input. Accumulate all errors.
 /// On success, return the (unchanged) input.
+///
+/// When chaining three or more error-accumulating checks, the pipe
+/// `a |> validator.both(b) |> validator.both(c)` works but reads
+/// awkwardly past two steps — "both" implies two things, not "and
+/// one more". `validator.also/2` is an alias of this function with
+/// the same semantics; pick whichever name fits the call site
+/// better, or use `validator.all([a, b, c])` for the list form
+/// once the chain grows beyond a handful of checks.
 pub fn both(
   first v1: Validator(a, e),
   second v2: Validator(a, e),
@@ -82,6 +90,18 @@ pub fn both(
         Invalid(non_empty_list.append(left: e1, right: e2))
     }
   }
+}
+
+/// Pipe-friendly alias of `validator.both/2` for chains of three or
+/// more error-accumulating checks. Reads as "this check also has to
+/// pass" at every step, instead of `both` (which implies two things).
+/// Identical semantics — picks the same error-accumulation behaviour
+/// — so the choice is purely stylistic.
+pub fn also(
+  first v1: Validator(a, e),
+  second v2: Validator(a, e),
+) -> Validator(a, e) {
+  both(first: v1, second: v2)
 }
 
 /// Run all validators on the same input. Accumulate all errors.

--- a/test/dataprep/validator_test.gleam
+++ b/test/dataprep/validator_test.gleam
@@ -139,6 +139,33 @@ pub fn both_chained_three_test() -> Nil {
     == Invalid(nel.make(first: IsEmpty, rest: [TooShort, TooLong]))
 }
 
+// --- also (alias of both) ---
+
+pub fn also_chained_three_matches_both_test() -> Nil {
+  let v1 = validator.predicate(fn(_: String) { False }, IsEmpty)
+  let v2 = validator.predicate(fn(_: String) { False }, TooShort)
+  let v3 = validator.predicate(fn(_: String) { False }, TooLong)
+
+  let via_also =
+    v1
+    |> validator.also(first: _, second: v2)
+    |> validator.also(first: _, second: v3)
+  let via_both =
+    v1
+    |> validator.both(first: _, second: v2)
+    |> validator.both(first: _, second: v3)
+
+  assert via_also("x") == via_both("x")
+}
+
+pub fn also_accumulates_errors_test() -> Nil {
+  let v1 = validator.predicate(fn(_: String) { False }, TooShort)
+  let v2 = validator.predicate(fn(_: String) { False }, TooLong)
+  let validator_under_test = validator.also(first: v1, second: v2)
+  assert validator_under_test("x")
+    == Invalid(nel.make(first: TooShort, rest: [TooLong]))
+}
+
 // --- all ---
 
 pub fn all_empty_validators_test() -> Nil {


### PR DESCRIPTION
## Summary

Adds `validator.also/2` as a pipe-friendly alias of `validator.both/2`. Both functions have identical error-accumulating semantics — `also` exists purely so chains of three or more checks read naturally at every step (`a |> also(b) |> also(c)`) instead of `both` (which implies "two things"). The `both/2` doc-comment now also points readers at the alias and at `validator.all([...])` for the list form once a chain grows past a handful of checks.

## Changes

- `src/dataprep/validator.gleam`: expand `both/2`'s doc-comment to call out the multi-step friction and introduce `validator.all([...])` as the list-form alternative; add `validator.also/2` directly underneath, delegating to `both/2` so a future change to the error-accumulation strategy applies to both names automatically.
- `test/dataprep/validator_test.gleam`: two new tests under a `// --- also (alias of both) ---` section. The equivalence test pipes the same three predicates through `also` and through `both` and asserts the resulting `Validated` values match — this is the strongest guarantee that the alias does not drift from `both`. The second test mirrors `both_accumulates_errors_test` to make sure the error-accumulation contract holds when `also` is used directly.
- `CHANGELOG.md`: `[Unreleased]` entry under `### Added` describing the alias.

## Design Decisions

`also/2` is a thin alias rather than a parallel implementation so the two names cannot drift apart. Future changes to error accumulation (for example, a different non-empty-list shape) flow through `both/2` and apply to `also/2` automatically.

The `both/2` doc-comment was expanded rather than left alone, even though the function itself is unchanged. The friction reported in #87 was a discoverability problem — callers reaching for "also" did not find `both`. Surfacing both names + `all` in the existing doc-comment fixes that without breaking any caller. The original semantics paragraph is preserved verbatim.

## Test plan

- [x] `gleam test` (Erlang target): 409 passed
- [x] `gleam test --target javascript`: 409 passed
- [x] `gleam format --check src test`: clean

Closes #87
