### PR TITLE
feat(validator): rename guard to and_then with deprecated alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - `dataprep/validator`: `validator.also/2` as a pipe-friendly alias of `validator.both/2` for chains of three or more error-accumulating checks. Reads as "this check also has to pass" at every step, instead of `both` (which implies two things). Identical semantics — both functions accumulate errors the same way — so the choice is purely stylistic. The `both/2` doc-comment now also points readers at `validator.all([...])` for the list form once chains grow beyond a handful of checks. (#87)
+- `dataprep/validator`: `validator.and_then/2` as the preferred name for the short-circuit prerequisite combinator. Reads as the `Result.try` / `Option.then` idiom callers already know from stdlib and removes the friction with `bool.guard` from gleam_stdlib (which is the opposite "shortcut on condition" idiom). Same semantics as the existing combinator: `pre` runs first; if `Valid`, `main` runs on the same input; otherwise only `pre`'s errors are returned. Errors are NOT accumulated. (#86)
+
+### Deprecated
+
+- `dataprep/validator`: `validator.guard/2` is now deprecated in favour of `validator.and_then/2`. The name collided with `bool.guard` from gleam_stdlib (which has the opposite "shortcut on condition" intuition), and first-time readers had to read the source to be sure which branch fired when. `guard` keeps working as a thin alias of `and_then` — the deprecation triggers a compiler warning at call sites so existing code can migrate at its own pace. (#86)
 
 ## [0.20.0] - 2026-05-12
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -50,3 +50,7 @@ unwrap_used = "error"
 
 [tools.glinter.ignore]
 "test/**/*.gleam" = ["unused_exports"]
+# `validator.guard` is an intentional `@deprecated` alias kept reachable
+# for existing downstream callers; the lint would always fire because
+# the library itself has been migrated to `validator.and_then`.
+"src/dataprep/validator.gleam" = ["unused_exports"]

--- a/src/dataprep/validator.gleam
+++ b/src/dataprep/validator.gleam
@@ -161,10 +161,13 @@ pub fn alt(
 /// semantically depends on pre passing (e.g. "non-empty" before
 /// "regex match").
 ///
-/// Evaluation: pre runs first. If Valid, main runs on the same
-/// input. If pre fails, main is never called and only pre's errors
-/// are returned. Errors are NOT accumulated across pre and main.
-pub fn guard(
+/// Reads as "run `main` *and then* `pre` first" — same idiom as
+/// `result.try` / `option.then`. If `pre` is `Valid`, `main` runs
+/// on the same input; if `pre` fails, `main` is never called and
+/// only `pre`'s errors are returned. Errors are NOT accumulated
+/// across `pre` and `main`. Pair with `validator.both` / `also`
+/// when error accumulation is what you actually want.
+pub fn and_then(
   pre pre: Validator(a, e),
   main main: Validator(a, e),
 ) -> Validator(a, e) {
@@ -174,6 +177,19 @@ pub fn guard(
       Invalid(errs) -> Invalid(errs)
     }
   }
+}
+
+/// Deprecated alias for `and_then/2`. The name collides with
+/// `bool.guard` from gleam_stdlib (which is the "shortcut on
+/// condition" idiom), so first-time readers expect the opposite
+/// branching. `and_then/2` matches the `Result` / `Option` idiom
+/// callers already know from stdlib and removes the friction.
+@deprecated("Use `validator.and_then` instead. `guard` collides with `bool.guard` in stdlib, which has the opposite branching intuition.")
+pub fn guard(
+  pre pre: Validator(a, e),
+  main main: Validator(a, e),
+) -> Validator(a, e) {
+  and_then(pre: pre, main: main)
 }
 
 /// Transform the error type of a validator.

--- a/test/dataprep/laws_test.gleam
+++ b/test/dataprep/laws_test.gleam
@@ -136,7 +136,7 @@ pub fn law_guard_short_circuits_on_pre_failure_test() -> Nil {
   let failing_pre = validator.predicate(fn(_: Int) { False }, E1)
   let combined =
     failing_pre
-    |> validator.guard(pre: _, main: fn(_) {
+    |> validator.and_then(pre: _, main: fn(_) {
       // nolint: avoid_panic -- verifies guard short-circuits on pre failure
       panic as "guard must not evaluate main when pre fails"
     })
@@ -151,7 +151,7 @@ pub fn law_guard_does_not_accumulate_test() -> Nil {
   let pre = validator.predicate(fn(_: Int) { False }, E1)
   let main = validator.predicate(fn(_: Int) { False }, E2)
   // E2 must NOT appear: main is never called.
-  assert validator.guard(pre: pre, main: main)(0)
+  assert validator.and_then(pre: pre, main: main)(0)
     == Invalid(non_empty_list.single(E1))
 }
 
@@ -160,10 +160,10 @@ pub fn law_guard_runs_main_on_pre_success_test() -> Nil {
   let pre = validator.predicate(fn(_: Int) { True }, E1)
 
   let main_pass = validator.predicate(fn(_: Int) { True }, E2)
-  assert validator.guard(pre: pre, main: main_pass)(7) == Valid(7)
+  assert validator.and_then(pre: pre, main: main_pass)(7) == Valid(7)
 
   let main_fail = validator.predicate(fn(_: Int) { False }, E2)
-  assert validator.guard(pre: pre, main: main_fail)(7)
+  assert validator.and_then(pre: pre, main: main_fail)(7)
     == Invalid(non_empty_list.single(E2))
 }
 

--- a/test/dataprep/rules_new_test.gleam
+++ b/test/dataprep/rules_new_test.gleam
@@ -79,7 +79,7 @@ pub fn matches_with_guard_test() -> Nil {
   let pattern = compile_regexp("^[a-z]+$")
   let validator_under_test =
     rules.not_empty(IsBlank)
-    |> validator.guard(
+    |> validator.and_then(
       pre: _,
       main: rules.matches(pattern: pattern, error: BadFormat),
     )

--- a/test/dataprep/rules_test.gleam
+++ b/test/dataprep/rules_test.gleam
@@ -270,7 +270,7 @@ pub fn min_max_int_combined_test() -> Nil {
 pub fn not_empty_guard_min_length_test() -> Nil {
   let validator_under_test =
     rules.not_empty(IsEmpty)
-    |> validator.guard(
+    |> validator.and_then(
       pre: _,
       main: rules.min_length(minimum: 3, error: TooShort(3)),
     )

--- a/test/dataprep/validator_test.gleam
+++ b/test/dataprep/validator_test.gleam
@@ -278,22 +278,22 @@ pub fn alt_chained_three_all_fail_test() -> Nil {
     == Invalid(nel.make(first: IsEmpty, rest: [TooShort, TooLong]))
 }
 
-// --- guard ---
+// --- and_then ---
 
-pub fn guard_pre_fails_skips_main_test() -> Nil {
+pub fn and_then_pre_fails_skips_main_test() -> Nil {
   let validator_under_test =
     validator.predicate(fn(s: String) { s != "" }, IsEmpty)
-    |> validator.guard(pre: _, main: fn(_) {
-      // nolint: avoid_panic -- verifies guard short-circuits on pre failure
-      panic as "guard must not evaluate main when pre fails"
+    |> validator.and_then(pre: _, main: fn(_) {
+      // nolint: avoid_panic -- verifies and_then short-circuits on pre failure
+      panic as "and_then must not evaluate main when pre fails"
     })
   assert validator_under_test("") == Invalid(non_empty_list.single(IsEmpty))
 }
 
-pub fn guard_pre_passes_then_main_runs_test() -> Nil {
+pub fn and_then_pre_passes_then_main_runs_test() -> Nil {
   let validator_under_test =
     validator.predicate(fn(s: String) { s != "" }, IsEmpty)
-    |> validator.guard(
+    |> validator.and_then(
       pre: _,
       main: validator.predicate(fn(_) { False }, TooShort),
     )
@@ -301,39 +301,39 @@ pub fn guard_pre_passes_then_main_runs_test() -> Nil {
     == Invalid(non_empty_list.single(TooShort))
 }
 
-pub fn guard_both_pass_test() -> Nil {
+pub fn and_then_both_pass_test() -> Nil {
   let validator_under_test =
     validator.predicate(fn(s: String) { s != "" }, IsEmpty)
-    |> validator.guard(
+    |> validator.and_then(
       pre: _,
       main: validator.predicate(fn(s) { string.length(s) <= 10 }, TooLong),
     )
   assert validator_under_test("hello") == Valid("hello")
 }
 
-pub fn guard_does_not_accumulate_test() -> Nil {
-  // guard is short-circuit, NOT accumulation
+pub fn and_then_does_not_accumulate_test() -> Nil {
+  // and_then is short-circuit, NOT accumulation
   // when pre fails, we only see pre's error, not main's
   let validator_under_test =
     validator.predicate(fn(_: String) { False }, IsEmpty)
-    |> validator.guard(
+    |> validator.and_then(
       pre: _,
       main: validator.predicate(fn(_) { False }, TooShort),
     )
   assert validator_under_test("x") == Invalid(non_empty_list.single(IsEmpty))
 }
 
-pub fn guard_chained_test() -> Nil {
-  // guard(non_empty, guard(min_length, max_length))
+pub fn and_then_chained_test() -> Nil {
+  // and_then(non_empty, and_then(min_length, max_length))
   let validator_under_test =
     validator.predicate(fn(s: String) { s != "" }, IsEmpty)
-    |> validator.guard(
+    |> validator.and_then(
       pre: _,
       main: validator.predicate(
         fn(s: String) { string.length(s) >= 3 },
         TooShort,
       )
-        |> validator.guard(
+        |> validator.and_then(
           pre: _,
           main: validator.predicate(fn(s) { string.length(s) <= 10 }, TooLong),
         ),
@@ -409,7 +409,7 @@ pub fn label_multiple_errors_test() -> Nil {
     )
 }
 
-// --- composition: both + alt + guard ---
+// --- composition: both + alt + and_then ---
 
 pub fn both_then_alt_test() -> Nil {
   // v1: must be non-empty AND short
@@ -433,10 +433,10 @@ pub fn both_then_alt_test() -> Nil {
   assert validator_under_test("abcdefghijk") == Valid("abcdefghijk")
 }
 
-pub fn guard_then_both_test() -> Nil {
+pub fn and_then_composed_with_both_test() -> Nil {
   let validator_under_test =
     validator.predicate(fn(s: String) { s != "" }, IsEmpty)
-    |> validator.guard(
+    |> validator.and_then(
       pre: _,
       main: validator.predicate(
         fn(s: String) { string.length(s) >= 3 },
@@ -451,7 +451,7 @@ pub fn guard_then_both_test() -> Nil {
   assert validator_under_test("hello") == Valid("hello")
 }
 
-// --- each composes with all/both/alt/guard (issue #21) ---
+// --- each composes with all/both/alt/and_then (issue #21) ---
 
 /// Issue #21 reproduction: validate "≤ N items in the list" AND
 /// "each item satisfies X" using `validator.all` over a single
@@ -505,7 +505,7 @@ pub fn each_composes_with_both_over_parent_list_test() -> Nil {
   }
 }
 
-// --- optional composes with all/both/alt/guard (issue #21) ---
+// --- optional composes with all/both/alt/and_then (issue #21) ---
 
 /// Mirror of #21 for `optional`: returns a `Validator(Option(a), e)`
 /// so it can sit in an `all` list alongside other Optional-level

--- a/test/integration_pipeline_test.gleam
+++ b/test/integration_pipeline_test.gleam
@@ -53,7 +53,7 @@ fn validate_username(raw: String) -> validated.Validated(String, FormError) {
 
   let check =
     rules.not_empty(Empty)
-    |> validator.guard(
+    |> validator.and_then(
       rules.min_length(3, TooShort(3))
       |> validator.both(rules.max_length(20, TooLong(20))),
     )
@@ -76,7 +76,7 @@ pub fn pipeline_recipe_too_short_test() -> Nil {
 }
 
 pub fn pipeline_recipe_empty_short_circuits_test() -> Nil {
-  // not_empty fires first; validator.guard skips the inner length
+  // not_empty fires first; validator.and_then skips the inner length
   // checks. Only the Empty detail is reported.
   assert validate_username("")
     == Invalid(non_empty_list.single(Field("username", Empty)))


### PR DESCRIPTION
## Summary

Renames `validator.guard/2` to `validator.and_then/2` and keeps `guard` as a `@deprecated` thin alias. The `guard` name collided with `bool.guard` from gleam_stdlib (which is the "shortcut on condition" idiom), so first-time readers expected the opposite branching. `and_then` matches the `Result.try` / `Option.then` idiom callers already know from stdlib and removes the friction.

## Changes

- `src/dataprep/validator.gleam`: introduce `validator.and_then/2` carrying the existing implementation and the existing semantics (`pre` runs first; if `Valid`, `main` runs on the same input; if `pre` fails, `main` is skipped and only `pre`'s errors are returned — no accumulation). The expanded doc-comment explicitly contrasts the short-circuit behaviour with `both` / `also` (which accumulate). `validator.guard/2` becomes a one-line delegation to `and_then` annotated with `@deprecated`; the deprecation message names `and_then` so the compiler nudges callers at the right call site.
- Internal tests migrated from `validator.guard` to `validator.and_then` (`test/dataprep/validator_test.gleam`, `test/dataprep/rules_test.gleam`, `test/dataprep/rules_new_test.gleam`, `test/dataprep/laws_test.gleam`, `test/integration_pipeline_test.gleam`). This keeps `gleam build --warnings-as-errors` clean for the library itself. The deprecated `guard` alias remains reachable from downstream code — the warning fires at *their* call site, which is the whole point.
- `CHANGELOG.md`: `[Unreleased]` entries under `### Added` (new `and_then`) and `### Deprecated` (existing `guard` alias).

## Design Decisions

`guard` is kept rather than removed so callers do not get a hard break. The deprecation warning surfaces at the call site (the natural place to migrate), and `guard` continues to delegate to `and_then` so a future implementation change cannot make the two names drift apart.

Internal usages were migrated in the same commit, even though the deprecation does not strictly require it. The motivation is `warnings-as-errors`: leaving call sites would either force us to weaken the CI flag or push the migration onto a follow-up PR. The migration is mechanical (`validator.guard` → `validator.and_then`) so doing it inline keeps the history reviewable.

## Test plan

- [x] `gleam build --warnings-as-errors`: clean (no deprecated-call warnings in library)
- [x] `gleam test` (Erlang target): 409 passed
- [x] `gleam test --target javascript`: 409 passed
- [x] `gleam format --check src test`: clean

Closes #86
