### PR TITLE
fix(rules)!: remove matches_fully(Regexp) — cannot implement re.fullmatch on alternation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Removed
+
+- `dataprep/rules`: `rules.matches_fully(pattern: regexp.Regexp, error: e)` is removed. The function took an already-compiled `Regexp` whose source pattern Gleam's `gleam/regexp` does not expose, which left no way to re-anchor the pattern as `^(?:...)$`; that prevented it from implementing Python `re.fullmatch` semantics for top-level alternation (`a|ab` against `"ab"` was rejected via leftmost-first matching). `rules.matches_fully_string(pattern: String, error: e)` and `rules.matches_fully_string_checked(pattern: String, error: e)` already compile the anchored pattern internally and behave correctly for all patterns; migrate by passing the pattern source string instead of a precompiled `Regexp`. **Breaking**. (#95)
+
 ## [0.21.0] - 2026-05-16
 
 ### Added

--- a/src/dataprep/rules.gleam
+++ b/src/dataprep/rules.gleam
@@ -41,10 +41,11 @@ pub fn not_blank(error: e) -> Validator(String, e) {
 /// `[0-9]+` accepts `"abc123def"` because the digit run matches
 /// somewhere in the input. To require the entire string to match,
 /// either anchor the pattern explicitly with `^...$`, or reach for
-/// `matches_fully` which enforces full-string semantics regardless
-/// of whether the pattern is anchored. The validation use case
-/// almost always wants `matches_fully`; `matches` is exposed for
-/// the cases that genuinely need substring search.
+/// `matches_fully_string` which enforces full-string semantics by
+/// anchoring the pattern source as `^(?:...)$` internally. The
+/// validation use case almost always wants `matches_fully_string`;
+/// `matches` is exposed for the cases that genuinely need
+/// substring search.
 ///
 /// Takes a pre-compiled `Regexp` so a malformed pattern surfaces as
 /// a `regexp.from_string` error at the call site instead of
@@ -64,52 +65,6 @@ pub fn matches(
   error error: e,
 ) -> Validator(String, e) {
   validator.predicate(fn(s) { regexp.check(re, s) }, error)
-}
-
-/// Fails if the regex does not match the entire input string. Unlike
-/// `matches`, a partial / substring hit is **not** enough — the
-/// matched substring must equal the whole input.
-///
-/// **Caveat — alternation:** because this function only has the
-/// already-compiled `Regexp`, it cannot re-anchor the pattern
-/// internally. The check is implemented by inspecting the first
-/// match returned by `regexp.scan`, which is leftmost-first. For
-/// patterns that use top-level alternation, the engine may pick a
-/// shorter alternative even though a longer one would also match
-/// the full input — e.g. `a|ab` on `"ab"` selects `a` and the
-/// validator then reports `Invalid` even though `re.fullmatch`
-/// would accept it. If your pattern uses `|`, prefer
-/// `matches_fully_string` / `matches_fully_string_checked` (which
-/// anchor the source pattern with `^(?:...)$` before compiling), or
-/// anchor the pattern explicitly yourself before passing it in.
-///
-/// For non-alternating patterns this matches Python's `re.fullmatch`
-/// semantics: anchoring with `^...$` is therefore not required, and
-/// patterns that already include `^` / `$` continue to work — the
-/// anchors just become redundant.
-///
-/// Example:
-///   import gleam/regexp
-///   import dataprep/rules
-///
-///   let assert Ok(re) = regexp.from_string("[0-9]+")
-///   let check = rules.matches_fully(pattern: re, error: NotANumber)
-///
-///   check("123")        // Valid("123")
-///   check("abc123def")  // Invalid([NotANumber])  -- substring match rejected
-pub fn matches_fully(
-  pattern re: regexp.Regexp,
-  error error: e,
-) -> Validator(String, e) {
-  validator.predicate(
-    fn(s) {
-      case regexp.scan(re, s) {
-        [Match(content: c, ..), ..] -> c == s
-        [] -> False
-      }
-    },
-    error,
-  )
 }
 
 /// Fails if the string does not match the given regular expression
@@ -149,6 +104,18 @@ pub fn matches_string(
     }
   }
 }
+
+// `matches_fully(pattern: regexp.Regexp, error: e)` was removed in
+// v0.22.0 because it cannot reliably implement Python `re.fullmatch`
+// semantics for top-level alternation: the function received an
+// already-compiled `regexp.Regexp` whose source pattern Gleam's
+// stdlib does not expose, which left no way to re-anchor the pattern
+// as `^(?:...)$`. Without anchoring the engine's leftmost-first
+// match for inputs like `a|ab` against `"ab"` returns `"a"` and the
+// validator reports `Invalid`. Use `matches_fully_string` (or
+// `matches_fully_string_checked`) with the original pattern source
+// instead — both compile the anchored pattern internally and
+// produce the expected `re.fullmatch` behaviour. See issue #95.
 
 /// Fails if the regex does not match the entire input string.
 /// Compiles the pattern internally with explicit anchors

--- a/test/dataprep/rules_new_test.gleam
+++ b/test/dataprep/rules_new_test.gleam
@@ -129,49 +129,34 @@ pub fn matches_string_unanchored_pattern_accepts_substring_hit_test() -> Nil {
     == Valid("abc123def")
 }
 
-// --- matches_fully ---
+// --- matches_fully_string: full-match-semantics scenarios ---
+// These previously exercised the removed `matches_fully(pattern:
+// Regexp, ...)` against compiled Regexps. After #95 the only public
+// "full match" entry point is `matches_fully_string`, which compiles
+// the pattern source itself and anchors as `^(?:...)$` — the same
+// behavioural scenarios live here against that API.
 
 pub fn matches_fully_full_match_passes_test() -> Nil {
-  let pattern = compile_regexp("[0-9]+")
-  assert rules.matches_fully(pattern: pattern, error: BadFormat)("123")
+  assert rules.matches_fully_string(pattern: "[0-9]+", error: BadFormat)("123")
     == Valid("123")
 }
 
-pub fn matches_fully_substring_hit_is_rejected_test() -> Nil {
-  let pattern = compile_regexp("[0-9]+")
-  assert rules.matches_fully(pattern: pattern, error: BadFormat)("abc123def")
-    == Invalid(non_empty_list.single(BadFormat))
-}
-
 pub fn matches_fully_no_match_at_all_is_rejected_test() -> Nil {
-  let pattern = compile_regexp("[0-9]+")
-  assert rules.matches_fully(pattern: pattern, error: BadFormat)("abc")
-    == Invalid(non_empty_list.single(BadFormat))
-}
-
-pub fn matches_fully_already_anchored_pattern_still_works_test() -> Nil {
-  // Patterns that already anchor with ^...$ continue to work — the
-  // anchors just become redundant under `matches_fully`.
-  let pattern = compile_regexp("^[a-z]+$")
-  assert rules.matches_fully(pattern: pattern, error: BadFormat)("abc")
-    == Valid("abc")
-  assert rules.matches_fully(pattern: pattern, error: BadFormat)("abc1")
+  assert rules.matches_fully_string(pattern: "[0-9]+", error: BadFormat)("abc")
     == Invalid(non_empty_list.single(BadFormat))
 }
 
 pub fn matches_fully_empty_input_with_star_pattern_test() -> Nil {
   // `.*` matches the empty string, and the empty match equals the
   // empty input — full-match semantics.
-  let pattern = compile_regexp(".*")
-  assert rules.matches_fully(pattern: pattern, error: BadFormat)("")
+  assert rules.matches_fully_string(pattern: ".*", error: BadFormat)("")
     == Valid("")
 }
 
 pub fn matches_fully_empty_input_with_plus_pattern_test() -> Nil {
   // `.+` requires at least one character; the empty input has no
   // match at all and is rejected.
-  let pattern = compile_regexp(".+")
-  assert rules.matches_fully(pattern: pattern, error: BadFormat)("")
+  assert rules.matches_fully_string(pattern: ".+", error: BadFormat)("")
     == Invalid(non_empty_list.single(BadFormat))
 }
 


### PR DESCRIPTION
## Summary

\`rules.matches_fully(pattern: regexp.Regexp, error: e)\` received a precompiled \`Regexp\` whose source string \`gleam/regexp\` does not expose. Without source-pattern access the function cannot re-anchor as \`^(?:...)$\`, so the regex engine's leftmost-first match selects the shorter alternative on top-level alternation (\`a|ab\` against \`\"ab\"\` was rejected because the engine picked \`a\`).

## Changes

- Remove \`rules.matches_fully(pattern: regexp.Regexp, error: e)\` from \`src/dataprep/rules.gleam\`. Replace its docblock with a brief tombstone comment that explains the API constraint and points readers at \`matches_fully_string\` / \`matches_fully_string_checked\`.
- Update the \`matches\` doc-comment that previously cross-referenced \`matches_fully\` to point at \`matches_fully_string\` instead.
- Migrate the four \`rules_new_test.gleam\` tests that exercised \`matches_fully(...)\` to use \`matches_fully_string(...)\` against the equivalent pattern source string. The \`already_anchored_pattern\` and \`substring_hit_rejected\` cases are dropped because they are already covered by the existing \`matches_fully_string_*\` tests; the alternation regression scenarios from the issue are likewise already covered by \`matches_fully_string_top_level_alternation_test\` and \`matches_fully_string_alternation_realistic_patterns_test\`.
- CHANGELOG \`### Removed\` entry under \`[Unreleased]\` documenting the breaking change and the migration.

## Design Decisions

The issue listed three options. 方針 A (internally anchor with \`^(?:pattern)$\`) is the only one that genuinely makes alternation work, but it requires access to the original pattern source, which \`gleam/regexp.Regexp\` does not provide. 方針 B (walk all matches from \`regexp.scan\`) does not actually help — \`scan\` returns the engine's leftmost-first non-overlapping matches and never visits the longer alternative once the shorter one consumed a position. 方針 C (docs-only) leaves the regression in place.

A working "method A" equivalent already exists in the form of \`matches_fully_string(pattern: String, error: e)\` (and the \`_checked\` variant), added as the original fix for #47. Removing the broken \`matches_fully(Regexp)\` entry point — rather than leaving it as a deprecated trap — points every caller at the function that does the right thing for all patterns including alternation.

## Limitations

This is a **breaking change** for any caller of \`rules.matches_fully(pattern: re, error: e)\`. Migrate by passing the pattern source string to \`matches_fully_string\` (or \`matches_fully_string_checked\` for dynamic patterns) instead of compiling the regex first and passing the \`Regexp\`. The CHANGELOG entry documents the migration.

Closes #95