### PR TITLE
chore(release): prepare v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-05-20
+
 ### Changed
 
 - `dataprep/prep`: `prep.replace(target: "", replacement: _)` now panics at construction time with `dataprep/prep.replace: target must be non-empty` instead of building a no-op transform. The underlying `gleam/string.replace` silently leaves the input untouched when the target is empty (the empty string matches at every position, which has no meaningful "replace once" interpretation), so the empty-target case used to hide caller typos like swapped argument labels. Guard at the call site when `target` comes from configuration or user input. **Breaking** for callers that relied on the silent no-op behaviour. (#99)

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "dataprep"
-version = "0.21.0"
+version = "0.22.0"
 description = "Composable, type-driven preprocessing and validation combinator library"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "dataprep" }


### PR DESCRIPTION
### Changed

- `dataprep/prep`: `prep.replace(target: "", replacement: _)` now panics at construction time with `dataprep/prep.replace: target must be non-empty` instead of building a no-op transform. The underlying `gleam/string.replace` silently leaves the input untouched when the target is empty (the empty string matches at every position, which has no meaningful "replace once" interpretation), so the empty-target case used to hide caller typos like swapped argument labels. Guard at the call site when `target` comes from configuration or user input. **Breaking** for callers that relied on the silent no-op behaviour. (#99)
- `dataprep/rules`: `rules.min_length(minimum: m, error: e)` and `rules.max_length(maximum: m, error: e)` now panic at construction time when `m < 0` instead of silently returning a no-op (for `min_length`) or always-fail (for `max_length`) validator. `string.length` is always `>= 0`, so a negative bound produces a vacuously true / vacuously false predicate; the case is almost always a config or arithmetic bug and is surfaced as one. The panic message names the function and echoes the offending value (`dataprep/rules.min_length: minimum (-1) must be >= 0`). Zero remains a valid bound — `min_length(0)` accepts every input, `max_length(0)` accepts only the empty string. **Breaking** for callers that relied on the silent no-op / always-fail behaviour. (#98)
- `dataprep/rules`: `rules.length_between(minimum: m, maximum: n, error: e)` with `m > n` now panics at construction time with `dataprep/rules.length_between: minimum (m) must be <= maximum (n)` instead of silently returning an always-fail validator. An inverted `[min, max]` interval has no inhabitants, so any validator built from it would reject every input — that is a programmer error and is surfaced as one. Guard the bounds at the call site when `min`/`max` come from configuration or other dynamic input. **Breaking** for callers that relied on the silent always-fail behaviour. (#97)
- `dataprep/rules`: `rules.one_of(allowed: [], error: e)` now panics at construction time with `dataprep/rules.one_of: allowed list must be non-empty` instead of silently returning an always-fail validator. A set-membership check against the empty set has no inhabitants, so any validator built from `[]` would reject every input — that is a programmer error and is surfaced as one. Guard at the call site when the allowlist comes from configuration or other dynamic input (e.g., `case allowed { [] -> ...; [_, ..] -> rules.one_of(allowed, e) }`). **Breaking** for callers that relied on the silent always-fail behaviour. (#96)

### Removed

- `dataprep/rules`: `rules.matches_fully(pattern: regexp.Regexp, error: e)` is removed. The function took an already-compiled `Regexp` whose source pattern Gleam's `gleam/regexp` does not expose, which left no way to re-anchor the pattern as `^(?:...)$`; that prevented it from implementing Python `re.fullmatch` semantics for top-level alternation (`a|ab` against `"ab"` was rejected via leftmost-first matching). `rules.matches_fully_string(pattern: String, error: e)` and `rules.matches_fully_string_checked(pattern: String, error: e)` already compile the anchored pattern internally and behave correctly for all patterns; migrate by passing the pattern source string instead of a precompiled `Regexp`. **Breaking**. (#95)
