### PR TITLE
feat(validated): add and_map applicative chain (closes #107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `dataprep/validated`: `validated.and_map(vf, va)` is an applicative-apply companion that lets the first `Validated` value flow into a pipe and chain to any number of further values — `v1 |> validated.map(curried) |> validated.and_map(v2) |> validated.and_map(v3)` — accumulating errors from every `Invalid` in the chain in left-to-right order. The existing `map2`..`map5` keep the function-first shape for direct calls and `combine2`..`combine5` cover the fixed-arity pipe shape; `and_map` fills the arbitrary-arity pipe gap that callers starting from the value-first `validated.map` expected. Re-verification follow-up to #83. (#107)
+
 ## [0.22.0] - 2026-05-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ More examples are available in the [doc/recipes/](https://github.com/nao1215/dat
 |--------|---------------|
 | `dataprep/prep` | Infallible transformations: `trim`, `lowercase`, `uppercase`, `collapse_space` (ASCII whitespace only), `collapse_unicode_space` (full Unicode `\s`), `replace`, `default`, `default_when_blank`. Compose with `then` or `sequence`. |
 | `dataprep/validator` | Checks without transformation: `check`, `predicate`, `both`, `all`, `alt`, `and_then`, `map_error`, `label`, `each`, `optional`. |
-| `dataprep/validated` | Applicative error accumulation: `map`, `map_error`, `and_then`, `from_result`, `from_result_map`, `to_result`, `map2`..`map5`, `sequence`, `traverse`, `traverse_indexed`. |
+| `dataprep/validated` | Applicative error accumulation: `map`, `map_error`, `and_then`, `from_result`, `from_result_map`, `to_result`, `map2`..`map5`, `combine2`..`combine5` (pipe-friendly, fixed arity), `and_map` (pipe-friendly applicative chain, any arity), `sequence`, `traverse`, `traverse_indexed`. |
 | `dataprep/non_empty_list` | At-least-one guarantee for error lists: `single`, `cons`, `append`, `concat`, `map`, `flat_map`, `to_list`, `from_list`. |
 | `dataprep/rules` | Built-in rules: `not_empty`, `not_blank`, `matches`, `matches_string`, `matches_string_checked`, `matches_fully`, `matches_fully_string`, `matches_fully_string_checked`, `min_length`, `max_length`, `length_between`, `min_int`, `max_int`, `min_float`, `max_float`, `non_negative_int`, `non_negative_float`, `one_of`, `equals`. |
 | `dataprep/parse` | Parse helpers: `int`, `float`, `float_strict`. Bridge `String` to typed `Validated` with custom error mapping. |
@@ -345,7 +345,7 @@ More examples are available in the [doc/recipes/](https://github.com/nao1215/dat
 | Validate | `validator.both` / `all` | Accumulate all | Independent checks on same value |
 | Validate | `validator.alt` | Accumulate on full failure | Accept alternative forms |
 | Validate | `validator.and_then` | Short-circuit | Skip if prerequisite fails |
-| Combine | `validated.map2`..`map5` | Accumulate all | Build domain types from independent fields |
+| Combine | `validated.map2`..`map5` / `combine2`..`combine5` / `and_map` | Accumulate all | Build domain types from independent fields (use `combineN` / `and_map` to pipe the first value in) |
 | Bridge | `validated.and_then` | Short-circuit | Parse then validate (type changes) |
 | Bridge | `parse.int` / `parse.float` | Short-circuit | String to typed Validated in one step |
 | Bridge | `raw \|> prep \|> validator` | (prep has none) | Apply infallible transform before validation |

--- a/src/dataprep/validated.gleam
+++ b/src/dataprep/validated.gleam
@@ -135,6 +135,35 @@ pub fn map5(
   )
 }
 
+/// Applicative apply: feed the next `Validated` argument into a
+/// `Validated` function, accumulating errors from both sides.
+///
+/// This is the pipe-friendly, arbitrary-arity companion to
+/// [map2](#map2)..[map5](#map5). Where `combine2`..`combine5` cover the
+/// fixed-arity cases, `and_map` lets the first `Validated` value flow in
+/// through a pipe and chain to any number of further values:
+///
+///   v1
+///   |> map(fn(a) { fn(b) { fn(c) { f(a, b, c) } } })
+///   |> and_map(v2)
+///   |> and_map(v3)
+///
+/// Like `map2`, it is error-accumulating: every `Invalid` in the chain
+/// contributes its errors in left-to-right order, so a fully-invalid
+/// chain reports all of its problems at once rather than short-circuiting.
+pub fn and_map(
+  func vf: Validated(fn(a) -> b, e),
+  value va: Validated(a, e),
+) -> Validated(b, e) {
+  case vf, va {
+    Valid(f), Valid(a) -> Valid(f(a))
+    Valid(_), Invalid(ea) -> Invalid(ea)
+    Invalid(ef), Valid(_) -> Invalid(ef)
+    Invalid(ef), Invalid(ea) ->
+      Invalid(non_empty_list.append(left: ef, right: ea))
+  }
+}
+
 /// Pipe-friendly form of [map2](#map2): takes the receivers first and
 /// the combining function last via the `with` label, so the first
 /// `Validated` can flow in through a pipe.

--- a/test/dataprep/validated_test.gleam
+++ b/test/dataprep/validated_test.gleam
@@ -401,3 +401,74 @@ pub fn combine5_accumulates_errors_test() -> Nil {
     )
     == Invalid(nel.make(first: "a", rest: ["c", "e"]))
 }
+
+// --- and_map (applicative chain, regression guard for #107) ---
+//
+// #107 re-reported #83: `map2..5` take the function first, so a `Validated`
+// value cannot flow into them through a pipe. `combine2..5` already cover the
+// fixed-arity pipe shape; `and_map` covers the arbitrary-arity applicative
+// chain `v1 |> map(curried) |> and_map(v2) |> and_map(v3) |> ...`. These tests
+// pin both the happy path AND error accumulation so the ergonomic trap the
+// closed issue described cannot silently come back.
+
+pub fn and_map_pipe_chain_valid_test() -> Nil {
+  // The exact Definition-of-Done shape from issue #107 (Option 2).
+  assert Valid(1)
+    |> validated.map(fn(a) { fn(b) { fn(c) { a + b + c } } })
+    |> validated.and_map(Valid(2))
+    |> validated.and_map(Valid(3))
+    == Valid(6)
+}
+
+pub fn and_map_two_values_test() -> Nil {
+  assert Valid(10)
+    |> validated.map(fn(a) { fn(b) { a + b } })
+    |> validated.and_map(Valid(5))
+    == Valid(15)
+}
+
+pub fn and_map_accumulates_all_errors_test() -> Nil {
+  // The applicative contract: every Invalid in the chain contributes its
+  // errors, in left-to-right order. This is the property a function-first
+  // `map2` pipe could never express ergonomically.
+  assert Invalid(non_empty_list.single("a"))
+    |> validated.map(fn(a) { fn(b) { fn(c) { #(a, b, c) } } })
+    |> validated.and_map(Invalid(non_empty_list.single("b")))
+    |> validated.and_map(Invalid(non_empty_list.single("c")))
+    == Invalid(nel.make(first: "a", rest: ["b", "c"]))
+}
+
+pub fn and_map_mixed_valid_invalid_test() -> Nil {
+  assert Valid(1)
+    |> validated.map(fn(a) { fn(b) { fn(c) { a + b + c } } })
+    |> validated.and_map(Invalid(non_empty_list.single("b")))
+    |> validated.and_map(Valid(3))
+    == Invalid(nel.make(first: "b", rest: []))
+}
+
+pub fn and_map_invalid_function_keeps_its_errors_test() -> Nil {
+  // When the left (function) side already carries errors and the right side
+  // is Valid, the function-side errors survive untouched.
+  assert Invalid(non_empty_list.single("fn-err"))
+    |> validated.and_map(Valid(99))
+    == Invalid(nel.make(first: "fn-err", rest: []))
+}
+
+pub fn and_map_chain_matches_map3_test() -> Nil {
+  // Regression anchor: the new pipe-friendly chain must agree with the
+  // existing low-level `map3` for the same inputs — both the valid result
+  // and the accumulated-error result — so the two surfaces cannot drift.
+  let chain = fn(va, vb, vc) {
+    va
+    |> validated.map(fn(a) { fn(b) { fn(c) { Triple(a, b, c) } } })
+    |> validated.and_map(vb)
+    |> validated.and_map(vc)
+  }
+
+  assert chain(Valid(1), Valid(2), Valid(3))
+    == validated.map3(Triple, Valid(1), Valid(2), Valid(3))
+
+  let e_a = Invalid(non_empty_list.single("a"))
+  let e_c = Invalid(non_empty_list.single("c"))
+  assert chain(e_a, Valid(2), e_c) == validated.map3(Triple, e_a, Valid(2), e_c)
+}


### PR DESCRIPTION
## Summary

Re-verification of closed issue #83 reported as #107: `validated.map2`..`map5` take the combining function as their **first** parameter, so a `Validated` value cannot flow into them through a pipe. The single-arity `validated.map` is value-first, which sets the expectation that the `mapN` family pipes the same way.

The package already ships `combine2`..`combine5` (value-first, function via the `with` label) for the **fixed-arity** pipe shape. What was missing is the **arbitrary-arity applicative chain**, which is the shape the issue's Definition-of-Done (Option 2) asks for.

## Change

Add `validated.and_map(func, value)` — applicative apply that feeds the next `Validated` argument into a `Validated`-wrapped function, accumulating errors from both sides:

```gleam
v1
|> validated.map(fn(a) { fn(b) { fn(c) { f(a, b, c) } } })
|> validated.and_map(v2)
|> validated.and_map(v3)
```

Like `map2`, it is error-accumulating: every `Invalid` in the chain contributes its errors in left-to-right order, so a fully-invalid chain reports all problems at once rather than short-circuiting. Non-breaking — `map2`..`map5` and `combine2`..`combine5` are unchanged.

## Tests (regression guard)

Because this is a recurrence of a previously-closed issue, the tests pin the behaviour from both directions so it cannot quietly come back:

- happy-path chains for arity 2 and 3 (the exact DoD shape),
- error accumulation across multiple `Invalid` values in the chain,
- mixed valid/invalid and function-side-invalid cases,
- an anchor test asserting the `and_map` chain agrees with the existing low-level `map3` for **both** the valid result and the accumulated-error result, so the new pipe surface and the old surface cannot drift apart.

`just ci` (deps + format-check + glinter + typecheck + build `--warnings-as-errors` + test) passes; 411 tests green.

Closes #107


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `and_map` combinator to the validated module, enabling a new pattern for combining validated values in functional pipelines.

* **Documentation**
  * Updated CHANGELOG.md to document the new `and_map` API and its position within the validated combinator family.
  * Updated README.md module and composition tables to list `and_map` alongside other validated combinators.

* **Tests**
  * Added comprehensive test coverage for `and_map` across multiple scenarios including pipe-chain behavior, multiple values, error handling, and consistency with existing operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/dataprep/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->