### PR TITLE
feat(prep): add replace_checked companion (closes #106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `dataprep/prep`: `prep.replace_checked(target:, replacement:) -> Result(Prep(String), PrepError)` is a `Result`-returning companion to `prep.replace` for callers whose `target` comes from runtime input (search fields, configuration, CSV) rather than a known-good literal. It returns `Error(EmptyTarget)` instead of panicking on an empty target, matching the `_checked` convention used elsewhere in the package. `prep.replace` is now defined in terms of `replace_checked` (panicking on `Error(EmptyTarget)`), so the checked and unchecked constructors cannot drift. The new `PrepError` type (variant `EmptyTarget`) names the failure. (#106)
 - `dataprep/validated`: `validated.and_map(vf, va)` is an applicative-apply companion that lets the first `Validated` value flow into a pipe and chain to any number of further values — `v1 |> validated.map(curried) |> validated.and_map(v2) |> validated.and_map(v3)` — accumulating errors from every `Invalid` in the chain in left-to-right order. The existing `map2`..`map5` keep the function-first shape for direct calls and `combine2`..`combine5` cover the fixed-arity pipe shape; `and_map` fills the arbitrary-arity pipe gap that callers starting from the value-first `validated.map` expected. Re-verification follow-up to #83. (#107)
 
 ## [0.22.0] - 2026-05-20

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ More examples are available in the [doc/recipes/](https://github.com/nao1215/dat
 
 | Module | Responsibility |
 |--------|---------------|
-| `dataprep/prep` | Infallible transformations: `trim`, `lowercase`, `uppercase`, `collapse_space` (ASCII whitespace only), `collapse_unicode_space` (full Unicode `\s`), `replace`, `default`, `default_when_blank`. Compose with `then` or `sequence`. |
+| `dataprep/prep` | Infallible transformations: `trim`, `lowercase`, `uppercase`, `collapse_space` (ASCII whitespace only), `collapse_unicode_space` (full Unicode `\s`), `replace` (panics on empty target), `replace_checked` (`Result`-returning sibling for runtime-supplied targets), `default`, `default_when_blank`. Compose with `then` or `sequence`. |
 | `dataprep/validator` | Checks without transformation: `check`, `predicate`, `both`, `all`, `alt`, `and_then`, `map_error`, `label`, `each`, `optional`. |
 | `dataprep/validated` | Applicative error accumulation: `map`, `map_error`, `and_then`, `from_result`, `from_result_map`, `to_result`, `map2`..`map5`, `combine2`..`combine5` (pipe-friendly, fixed arity), `and_map` (pipe-friendly applicative chain, any arity), `sequence`, `traverse`, `traverse_indexed`. |
 | `dataprep/non_empty_list` | At-least-one guarantee for error lists: `single`, `cons`, `append`, `concat`, `map`, `flat_map`, `to_list`, `from_list`. |

--- a/src/dataprep/prep.gleam
+++ b/src/dataprep/prep.gleam
@@ -36,6 +36,18 @@ import gleam/string
 pub type Prep(a) =
   fn(a) -> a
 
+/// Reason a `_checked` constructor could not build a prep from the
+/// supplied arguments. The panicking constructors (`replace`) reject the
+/// same cases at construction time; the `_checked` siblings surface them
+/// as data so callers with runtime-supplied arguments can recover.
+pub type PrepError {
+  /// `replace_checked` was called with an empty `target`. The empty
+  /// string matches at every position, which the underlying
+  /// `string.replace` turns into a silent no-op — almost always a
+  /// swapped-argument or unintended-runtime-value bug.
+  EmptyTarget
+}
+
 /// Sequential composition: apply p1, then apply p2 to the result.
 ///
 /// FP-leaning users often grep for `compose` first; `prep.compose/2`
@@ -156,11 +168,37 @@ pub fn replace(
   target target: String,
   replacement replacement: String,
 ) -> Prep(String) {
-  case target {
-    "" ->
+  case replace_checked(target:, replacement:) {
+    Ok(prepper) -> prepper
+    Error(EmptyTarget) ->
       // nolint: avoid_panic -- empty target is a programmer error; the underlying string.replace silently no-ops, which hides the bug at runtime
       panic as "dataprep/prep.replace: target must be non-empty"
-    _ -> fn(s) { string.replace(in: s, each: target, with: replacement) }
+  }
+}
+
+/// `Result`-returning companion to [`replace`](#replace) for callers
+/// whose `target` comes from runtime input (user-typed search fields,
+/// configuration, CSV columns) rather than a known-good literal. Returns
+/// `Error(EmptyTarget)` instead of panicking when `target` is empty, so
+/// the empty-target case can be handled as data:
+///
+/// ```gleam
+/// case prep.replace_checked(target: user_find, replacement: user_with) {
+///   Ok(prepper) -> Ok(prepper(input))
+///   Error(prep.EmptyTarget) -> Error("search text must not be empty")
+/// }
+/// ```
+///
+/// For a non-empty `target` the returned prep is identical to the one
+/// `replace` builds — `replace` is defined in terms of this function, so
+/// the two cannot drift apart.
+pub fn replace_checked(
+  target target: String,
+  replacement replacement: String,
+) -> Result(Prep(String), PrepError) {
+  case target {
+    "" -> Error(EmptyTarget)
+    _ -> Ok(fn(s) { string.replace(in: s, each: target, with: replacement) })
   }
 }
 

--- a/test/dataprep/prep_test.gleam
+++ b/test/dataprep/prep_test.gleam
@@ -1,4 +1,5 @@
 import dataprep/prep
+import gleam/result
 
 // --- identity ---
 
@@ -149,6 +150,40 @@ pub fn replace_absent_target_test() -> Nil {
 
 pub fn replace_to_empty_test() -> Nil {
   assert prep.replace(target: "e", replacement: "")("hello") == "hllo"
+}
+
+// --- replace_checked (runtime-supplied target, regression guard for #106) ---
+//
+// prep.replace panics at construction time on an empty target. That is the
+// right default for known-good code, but runtime-supplied targets (user input,
+// config, CSV) need a recoverable path. replace_checked returns the same prep
+// as replace for a valid target, and Error(EmptyTarget) instead of panicking.
+// These tests pin that the two constructors agree so they cannot drift.
+
+pub fn replace_checked_valid_target_test() -> Nil {
+  assert prep.replace_checked(target: "-", replacement: "_")
+    |> result.map(fn(prepper) { prepper("foo-bar-baz") })
+    == Ok("foo_bar_baz")
+}
+
+pub fn replace_checked_empty_target_is_error_test() -> Nil {
+  assert prep.replace_checked(target: "", replacement: "X")
+    == Error(prep.EmptyTarget)
+}
+
+pub fn replace_checked_matches_replace_for_valid_target_test() -> Nil {
+  // Regression anchor: the checked Ok path must behave identically to the
+  // unchecked constructor for the same valid arguments.
+  let unchecked = prep.replace(target: "e", replacement: "3")
+  assert prep.replace_checked(target: "e", replacement: "3")
+    |> result.map(fn(checked) { checked("level eleven") })
+    == Ok(unchecked("level eleven"))
+}
+
+pub fn replace_checked_no_match_test() -> Nil {
+  assert prep.replace_checked(target: "x", replacement: "y")
+    |> result.map(fn(prepper) { prepper("hello") })
+    == Ok("hello")
 }
 
 // --- default ---


### PR DESCRIPTION
## Summary

`prep.replace` panics at construction time on an empty `target` (`dataprep/prep.replace: target must be non-empty`). That is the right default for known-good literals, but every other "could-fail-at-construction" function in the package ships a `_checked` sibling — `replace` was the odd one out. For runtime-supplied targets (a user-typed search field, configuration, a CSV column) callers had no recoverable path and risked an unhandled panic in production.

## Change

Add `prep.replace_checked(target:, replacement:) -> Result(Prep(String), PrepError)`, returning `Error(EmptyTarget)` instead of panicking on an empty target:

```gleam
case prep.replace_checked(target: user_find, replacement: user_with) {
  Ok(prepper) -> Ok(prepper(input))
  Error(prep.EmptyTarget) -> Error("search text must not be empty")
}
```

`prep.replace` is now **defined in terms of** `replace_checked` (it panics on `Error(EmptyTarget)`), so the checked and unchecked constructors share one source of truth and cannot drift apart. A new `PrepError` type (variant `EmptyTarget`) names the failure, so it shows up in CHANGELOG and hexdocs.

## Tests (regression guard)

- `Error(EmptyTarget)` is returned for an empty target,
- the `Ok` path builds a working prep (replace-all, no-match),
- an anchor test asserts the checked `Ok` path behaves **identically** to the unchecked `prep.replace` for the same valid arguments, so the shared-implementation guarantee is enforced by a test rather than just by reading the code.

`just ci` (deps + format-check + glinter + typecheck + build `--warnings-as-errors` + test) passes; 415 tests green.

Closes #106
